### PR TITLE
feat(infra): add mock ActivityPub instance for auth testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ API_SECRET_KEY=changeme-dev-secret
 
 # vLLM (RunPod, non utilisé en dev local)
 VLLM_BASE_URL=https://your-runpod-endpoint/v1
+# Mock ActivityPub instance (profile: mock)
+MOCK_DOMAIN=mock-instance
+MOCK_PORT=8080

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -54,6 +54,18 @@ services:
       postgres:
         condition: service_healthy
 
+  mock-instance:
+    build:
+      context: ./mock-instance
+    environment:
+      MOCK_DOMAIN: ${MOCK_DOMAIN:-mock-instance}
+    ports:
+      - "${MOCK_PORT:-8080}:8080"
+    networks:
+      - hub_net
+    profiles:
+      - mock
+
 volumes:
   postgres_data:
   minio_data:

--- a/infra/mock-instance/.dockerignore
+++ b/infra/mock-instance/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/infra/mock-instance/Dockerfile
+++ b/infra/mock-instance/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/infra/mock-instance/main.py
+++ b/infra/mock-instance/main.py
@@ -1,0 +1,114 @@
+import base64
+import hashlib
+import os
+from email.utils import formatdate
+from urllib.parse import urlparse
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+MOCK_DOMAIN: str = os.getenv("MOCK_DOMAIN", "mock-instance")
+ACTOR_ID: str = f"http://{MOCK_DOMAIN}/actor"
+KEY_ID: str = f"{ACTOR_ID}#main-key"
+
+_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_public_key = _private_key.public_key()
+
+PUBLIC_KEY_PEM: str = _public_key.public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode()
+
+app = FastAPI(title="Mock ActivityPub Instance", version="0.1.0")
+
+
+@app.get("/.well-known/webfinger")
+def webfinger(resource: str = Query(...)):
+    expected = f"acct:hub@{MOCK_DOMAIN}"
+    if resource != expected:
+        raise HTTPException(status_code=404, detail=f"Unknown resource: {resource}")
+
+    return JSONResponse(
+        content={
+            "subject": resource,
+            "links": [
+                {
+                    "rel": "self",
+                    "type": "application/activity+json",
+                    "href": ACTOR_ID,
+                }
+            ],
+        },
+        media_type="application/jrd+json",
+    )
+
+
+@app.get("/actor")
+def actor():
+    return JSONResponse(
+        content={
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://w3id.org/security/v1",
+            ],
+            "id": ACTOR_ID,
+            "type": "Person",
+            "preferredUsername": "hub",
+            "inbox": f"http://{MOCK_DOMAIN}/inbox",
+            "publicKey": {
+                "id": KEY_ID,
+                "owner": ACTOR_ID,
+                "publicKeyPem": PUBLIC_KEY_PEM,
+            },
+        },
+        media_type="application/activity+json",
+    )
+
+
+class SignRequestBody(BaseModel):
+    method: str
+    url: str
+    body: str = ""
+
+
+@app.post("/sign-request")
+def sign_request(data: SignRequestBody):
+    method = data.method.lower()
+    parsed = urlparse(data.url)
+    host = parsed.netloc or MOCK_DOMAIN
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    date = formatdate(usegmt=True)
+
+    body_bytes = data.body.encode("utf-8") if data.body else b""
+    digest = "SHA-256=" + base64.b64encode(hashlib.sha256(body_bytes).digest()).decode()
+
+    signing_string = (
+        f"(request-target): {method} {path}\n"
+        f"host: {host}\n"
+        f"date: {date}\n"
+        f"digest: {digest}"
+    )
+
+    signature_b64 = base64.b64encode(
+        _private_key.sign(signing_string.encode("utf-8"), padding.PKCS1v15(), hashes.SHA256())
+    ).decode()
+
+    return {
+        "headers": {
+            "Host": host,
+            "Date": date,
+            "Digest": digest,
+            "Signature": (
+                f'keyId="{KEY_ID}",'
+                f'algorithm="rsa-sha256",'
+                f'headers="(request-target) host date digest",'
+                f'signature="{signature_b64}"'
+            ),
+        }
+    }

--- a/infra/mock-instance/requirements.txt
+++ b/infra/mock-instance/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.115,<1.0
+uvicorn[standard]>=0.32,<1.0
+cryptography>=42,<45


### PR DESCRIPTION
## Summary

- Add `infra/mock-instance/` service: FastAPI app simulating a Suddenly Fediverse instance
- Generates RSA 2048 key pair at startup (ephemeral, not persisted)
- Exposes `GET /.well-known/webfinger` and `GET /actor` for ActivityPub key resolution
- Exposes `POST /sign-request` utility to generate draft-cavage HTTP Signatures for integration tests
- Integrated in Docker Compose under `--profile mock` (not started by default)
- Adds `MOCK_DOMAIN` and `MOCK_PORT` variables to `.env.example`

## Test plan

- [ ] `docker compose --profile mock up mock-instance` démarre sans erreur
- [ ] `GET http://localhost:8080/.well-known/webfinger?resource=acct:hub@mock-instance` retourne JRD avec lien self
- [ ] `GET http://localhost:8080/actor` retourne un objet Person AP avec `publicKey.publicKeyPem`
- [ ] `POST http://localhost:8080/sign-request` avec `{"method":"POST","url":"http://gateway:8000/v1/contribute","body":"{}"}` retourne headers `Signature`, `Date`, `Digest`, `Host`

Closes #7