### PR TITLE
feat(training): add Axolotl QLoRA configs for base models and LoRA adapters

### DIFF
--- a/training/lora-situation.yml
+++ b/training/lora-situation.yml
@@ -1,0 +1,108 @@
+# lora-situation.yml — TEMPLATE LoRA adapter axe situation
+#
+# Ce fichier est un TEMPLATE. Avant de lancer un entraînement, substituer :
+#   ADAPTER_NAME   → slug de la situation, ex: combat
+#   DATASET_PATH   → chemin vers le JSONL du corpus de cette situation
+#   OUTPUT_DIR     → répertoire de sortie, ex: ./outputs/lora-combat
+#   BASE_MODEL_DIR → chemin ou HF id du modèle suddenly-7b déjà fine-tuné
+#
+# Situations valides :
+#   romance, combat, enquete, diplomatie, exploration, introspection
+#
+# Seuil de déclenchement : 500 sessions pour cette situation
+# Compatible vLLM via PEFT (noms de couches préservés par Axolotl, pas de merge inline)
+# Usage : axolotl train training/lora-situation.yml
+#         (après substitution des placeholders)
+
+base_model: BASE_MODEL_DIR   # ex: ./outputs/suddenly-7b ou mistralai/Mistral-7B-v0.3
+
+model_type: MistralForCausalLM
+tokenizer_type: LlamaTokenizer
+
+# --- Quantization ---
+load_in_4bit: true
+load_in_8bit: false
+bnb_config_kwargs:
+  bnb_4bit_quant_type: nf4
+  bnb_4bit_use_double_quant: true
+  bnb_4bit_compute_dtype: bfloat16
+
+# --- Adapter ---
+# Rank plus bas que l'axe univers : la situation est une spécialisation de style
+# plus étroite, moins de paramètres nécessaires
+adapter: qlora
+lora_r: 16
+lora_alpha: 32
+lora_dropout: 0.05
+lora_target_linear: true
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+# --- Dataset ---
+# JSONL de sessions filtrées pour cette situation (produit par pipeline/formatting)
+# Format attendu par ligne :
+#   {"messages": [{"role": "system", "content": "..."}, {"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+chat_template: mistral_v1
+datasets:
+  - path: DATASET_PATH    # ex: data/corpus-combat.jsonl
+    type: chat_template
+    roles_to_train:
+      - assistant
+    train_on_eos: turn
+
+dataset_prepared_path: .cache/lora-situation-ADAPTER_NAME-prepared
+val_set_size: 0.1         # 10% validation (corpus plus petit qu'un modèle de base)
+
+# --- Séquences ---
+sequence_len: 4096
+sample_packing: true
+pad_to_sequence_len: true
+
+# --- Output ---
+output_dir: OUTPUT_DIR    # ex: ./outputs/lora-combat
+lora_model_dir:           # laisser vide sauf pour continuer un entraînement
+
+# --- Entraînement ---
+num_epochs: 5
+micro_batch_size: 4
+gradient_accumulation_steps: 4
+# effective batch size = 4 * 4 = 16
+
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 2.0e-4
+warmup_ratio: 0.1
+weight_decay: 0.01
+
+# --- Précision et mémoire ---
+bf16: auto
+tf32: false
+flash_attention: true
+gradient_checkpointing: true
+
+# --- Logging et checkpoints ---
+logging_steps: 10
+evals_per_epoch: 4
+saves_per_epoch: 1
+save_total_limit: 2
+
+# --- Stabilité ---
+loss_watchdog_threshold: 5.0
+loss_watchdog_patience: 3
+max_grad_norm: 1.0
+
+# --- Wandb (optionnel) ---
+# wandb_project: suddenly-ai-hub
+# wandb_entity:
+# wandb_name: lora-situation-ADAPTER_NAME
+
+# --- Après entraînement : pre-merge ---
+# Le pipeline déclenche automatiquement merge_lora.py si lora-{univers} existe déjà.
+# Résultat : ./outputs/lora-{univers}-ADAPTER_NAME-merged/
+# hub_model_id: suddenly-ai/lora-situation-ADAPTER_NAME

--- a/training/lora-univers.yml
+++ b/training/lora-univers.yml
@@ -1,0 +1,108 @@
+# lora-univers.yml — TEMPLATE LoRA adapter axe univers (genre GROG)
+#
+# Ce fichier est un TEMPLATE. Avant de lancer un entraînement, substituer :
+#   ADAPTER_NAME   → slug du genre, ex: medieval-fantastique
+#   DATASET_PATH   → chemin vers le JSONL du corpus de ce genre
+#   OUTPUT_DIR     → répertoire de sortie, ex: ./outputs/lora-medieval-fantastique
+#   BASE_MODEL_DIR → chemin ou HF id du modèle suddenly-7b déjà fine-tuné
+#
+# Genres valides (taxonomie GROG — legrog.org/themes) :
+#   medieval-fantastique, historique-fantastique, scifi, contemporain-fantastique,
+#   space-opera, contemporain, post-apocalyptique, cyberpunk, super-heros,
+#   oriental-manga, generique
+#
+# Seuil de déclenchement : 500 sessions pour ce genre
+# Compatible vLLM via PEFT (noms de couches préservés par Axolotl, pas de merge inline)
+# Usage : axolotl train training/lora-univers.yml
+#         (après substitution des placeholders)
+
+base_model: BASE_MODEL_DIR   # ex: ./outputs/suddenly-7b ou mistralai/Mistral-7B-v0.3
+
+model_type: MistralForCausalLM
+tokenizer_type: LlamaTokenizer
+
+# --- Quantization ---
+load_in_4bit: true
+load_in_8bit: false
+bnb_config_kwargs:
+  bnb_4bit_quant_type: nf4
+  bnb_4bit_use_double_quant: true
+  bnb_4bit_compute_dtype: bfloat16
+
+# --- Adapter ---
+adapter: qlora
+lora_r: 32
+lora_alpha: 64
+lora_dropout: 0.05
+lora_target_linear: true
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+# --- Dataset ---
+# JSONL de sessions filtrées pour ce genre (produit par pipeline/formatting)
+# Format attendu par ligne :
+#   {"messages": [{"role": "system", "content": "..."}, {"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+chat_template: mistral_v1
+datasets:
+  - path: DATASET_PATH    # ex: data/corpus-medieval-fantastique.jsonl
+    type: chat_template
+    roles_to_train:
+      - assistant
+    train_on_eos: turn
+
+dataset_prepared_path: .cache/lora-univers-ADAPTER_NAME-prepared
+val_set_size: 0.1         # 10% validation (corpus plus petit qu'un modèle de base)
+
+# --- Séquences ---
+sequence_len: 4096
+sample_packing: true
+pad_to_sequence_len: true
+
+# --- Output ---
+output_dir: OUTPUT_DIR    # ex: ./outputs/lora-medieval-fantastique
+lora_model_dir:           # laisser vide sauf pour continuer un entraînement
+
+# --- Entraînement ---
+num_epochs: 5             # plus d'epochs : corpus plus petit, risque d'overfitting contrôlé par val
+micro_batch_size: 4
+gradient_accumulation_steps: 4
+# effective batch size = 4 * 4 = 16
+
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 2.0e-4
+warmup_ratio: 0.1
+weight_decay: 0.01
+
+# --- Précision et mémoire ---
+bf16: auto
+tf32: false
+flash_attention: true
+gradient_checkpointing: true
+
+# --- Logging et checkpoints ---
+logging_steps: 10
+evals_per_epoch: 4
+saves_per_epoch: 1
+save_total_limit: 2
+
+# --- Stabilité ---
+loss_watchdog_threshold: 5.0
+loss_watchdog_patience: 3
+max_grad_norm: 1.0
+
+# --- Wandb (optionnel) ---
+# wandb_project: suddenly-ai-hub
+# wandb_entity:
+# wandb_name: lora-univers-ADAPTER_NAME
+
+# --- Après entraînement : pre-merge ---
+# Le pipeline déclenche automatiquement merge_lora.py si lora-{situation} existe déjà.
+# Résultat : ./outputs/lora-ADAPTER_NAME-{situation}-merged/
+# hub_model_id: suddenly-ai/lora-univers-ADAPTER_NAME

--- a/training/scripts/runpod_train.sh
+++ b/training/scripts/runpod_train.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# runpod_train.sh — Lancement d'un entraînement Axolotl sur RunPod
+#
+# Usage :
+#   ./scripts/runpod_train.sh <config.yml>
+#   ./scripts/runpod_train.sh training/suddenly-7b.yml
+#   ./scripts/runpod_train.sh training/lora-univers.yml   # après substitution des placeholders
+#
+# Prérequis RunPod :
+#   - Template : axolotl-runpod (image officielle Axolotl, Axolotl + vLLM pré-installés)
+#   - GPU       : A100-40G (recommandé pour QLoRA 7B/12B)
+#   - Volume    : monter un Network Volume sur /workspace pour persistance entre runs
+#   - Env vars  : HF_TOKEN et éventuellement WANDB_API_KEY dans les secrets du pod
+#
+# Étape manuelle avant lancement :
+#   1. Copier ce repo sur le pod : git clone ou upload via RunPod File Browser
+#   2. Copier les JSONL du corpus dans training/data/ (depuis S3 ou upload direct)
+
+set -euo pipefail
+
+CONFIG="${1:-}"
+if [[ -z "$CONFIG" ]]; then
+    echo "Usage: $0 <config.yml>"
+    echo "  ex:  $0 training/suddenly-7b.yml"
+    exit 1
+fi
+
+WORKSPACE="/workspace"
+REPO_DIR="${WORKSPACE}/suddenly-ai-hub"
+
+# ---------------------------------------------------------------------------
+# 1. Authentification Hugging Face
+#    HF_TOKEN doit être défini dans les secrets RunPod ou exporté avant ce script
+# ---------------------------------------------------------------------------
+if [[ -z "${HF_TOKEN:-}" ]]; then
+    echo "[ERROR] HF_TOKEN non défini. Exporter la variable ou la définir dans les secrets RunPod."
+    exit 1
+fi
+huggingface-cli login --token "$HF_TOKEN" --add-to-git-credential
+
+# ---------------------------------------------------------------------------
+# 2. Installation d'Axolotl (si pas dans l'image)
+#    L'image axolotl-runpod l'inclut déjà. Ce bloc est un fallback.
+# ---------------------------------------------------------------------------
+if ! command -v axolotl &>/dev/null; then
+    echo "[INFO] Axolotl non trouvé — installation depuis pip..."
+    pip install axolotl[flash-attn,deepspeed] --quiet
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Vérifier que le config existe
+# ---------------------------------------------------------------------------
+CONFIG_PATH="${REPO_DIR}/${CONFIG}"
+if [[ ! -f "$CONFIG_PATH" ]]; then
+    # Essayer chemin absolu tel quel
+    CONFIG_PATH="${CONFIG}"
+fi
+if [[ ! -f "$CONFIG_PATH" ]]; then
+    echo "[ERROR] Config non trouvée : ${CONFIG}"
+    exit 1
+fi
+
+echo "[INFO] Config : ${CONFIG_PATH}"
+echo "[INFO] GPU disponible :"
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null || echo "(nvidia-smi absent)"
+
+# ---------------------------------------------------------------------------
+# 4. Lancement de l'entraînement
+# ---------------------------------------------------------------------------
+echo "[INFO] Démarrage entraînement..."
+cd "${REPO_DIR}"
+
+axolotl train "${CONFIG_PATH}"
+
+echo "[INFO] Entraînement terminé."
+
+# ---------------------------------------------------------------------------
+# 5. Sauvegarde vers S3 (optionnel)
+#    Nécessite AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET définis
+# ---------------------------------------------------------------------------
+# Extraire output_dir depuis le YAML (nécessite python ou yq)
+OUTPUT_DIR=$(python3 -c "
+import yaml, sys
+with open('${CONFIG_PATH}') as f:
+    cfg = yaml.safe_load(f)
+print(cfg.get('output_dir', './outputs/model'))
+")
+
+if [[ -n "${S3_BUCKET:-}" ]]; then
+    echo "[INFO] Upload vers S3 : s3://${S3_BUCKET}/models/$(basename ${OUTPUT_DIR})/"
+    aws s3 sync "${OUTPUT_DIR}" "s3://${S3_BUCKET}/models/$(basename ${OUTPUT_DIR})/" \
+        --exclude "*.tmp" \
+        --no-progress
+    echo "[INFO] Upload S3 terminé."
+else
+    echo "[INFO] S3_BUCKET non défini — sauvegarde locale uniquement dans ${OUTPUT_DIR}"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Upload Hugging Face Hub (optionnel)
+#    Décommenter et définir HF_REPO_ID si push vers HF Hub souhaité
+# ---------------------------------------------------------------------------
+# HF_REPO_ID="suddenly-ai/$(basename ${OUTPUT_DIR})"
+# echo "[INFO] Push vers HF Hub : ${HF_REPO_ID}"
+# huggingface-cli upload "${HF_REPO_ID}" "${OUTPUT_DIR}"
+
+echo "[INFO] Script terminé. Penser à terminer le pod RunPod pour éviter les frais."

--- a/training/suddenly-13b.yml
+++ b/training/suddenly-13b.yml
@@ -1,0 +1,99 @@
+# suddenly-13b.yml
+# Full fine-tuning du modèle de base Mistral NeMo 12B sur corpus RP long-contexte
+# Modèle retenu : mistralai/Mistral-Nemo-Base-2407 (12B, Apache 2.0, 128k ctx natif)
+# Raisons du choix vs LLaMA 3 13B :
+#   - Apache 2.0 (LLaMA 3 a des restrictions usage commercial)
+#   - 128k context natif (vs 8k LLaMA 3 base) — critique pour analyze_session/generate_summary
+#   - Drop-in replacement de Mistral 7B (même tokenizer Tekken, même architecture)
+#   - Compatible vLLM et même pipeline Axolotl que suddenly-7b
+# GPU cible : RunPod A100-40G (40GB VRAM) — QLoRA requis pour tenir en mémoire
+# Usage : axolotl train training/suddenly-13b.yml
+
+base_model: mistralai/Mistral-Nemo-Base-2407
+model_type: MistralForCausalLM
+tokenizer_type: AutoTokenizer
+
+# --- Quantization ---
+load_in_4bit: true
+load_in_8bit: false
+bnb_config_kwargs:
+  bnb_4bit_quant_type: nf4
+  bnb_4bit_use_double_quant: true
+  bnb_4bit_compute_dtype: bfloat16
+
+# --- Adapter ---
+adapter: qlora
+lora_r: 64
+lora_alpha: 128
+lora_dropout: 0.05
+lora_target_linear: true
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+# --- Dataset ---
+# Format : JSONL avec clé "messages", rôles system/user/assistant
+# Corpus long-contexte : sessions > 2k tokens (analyze_session, generate_summary, suggest_links)
+chat_template: mistral_v1
+datasets:
+  - path: data/corpus-rp-longctx.jsonl
+    type: chat_template
+    roles_to_train:
+      - assistant
+    train_on_eos: turn
+
+dataset_prepared_path: .cache/suddenly-13b-prepared
+val_set_size: 0.05
+
+# --- Séquences ---
+# Séquence réduite à 4096 pour tenir sur A100-40G avec 12B params
+# Pour exploiter les 128k : utiliser 2xA100-40G avec DeepSpeed ZeRO-3
+sequence_len: 4096
+sample_packing: true
+pad_to_sequence_len: true
+
+# --- Output ---
+output_dir: ./outputs/suddenly-13b
+
+# --- Entraînement ---
+num_epochs: 3
+micro_batch_size: 1
+gradient_accumulation_steps: 16
+# effective batch size = 1 * 16 = 16
+
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 1.0e-4
+warmup_ratio: 0.05
+weight_decay: 0.01
+
+# --- Précision et mémoire ---
+bf16: auto
+tf32: false
+flash_attention: true
+gradient_checkpointing: true
+
+# --- Logging et checkpoints ---
+logging_steps: 10
+evals_per_epoch: 4
+saves_per_epoch: 1
+save_total_limit: 3
+
+# --- Stabilité ---
+loss_watchdog_threshold: 5.0
+loss_watchdog_patience: 3
+max_grad_norm: 1.0
+
+# --- Wandb (optionnel) ---
+# wandb_project: suddenly-ai-hub
+# wandb_entity:
+# wandb_name: suddenly-13b-run-1
+
+# --- Hub (optionnel, après entraînement) ---
+# hub_model_id: suddenly-ai/suddenly-13b
+# hub_strategy: end

--- a/training/suddenly-7b.yml
+++ b/training/suddenly-7b.yml
@@ -1,0 +1,92 @@
+# suddenly-7b.yml
+# Full fine-tuning du modèle de base Mistral 7B v0.3 sur corpus RP général
+# Méthode : QLoRA sur A100-40G (full FFT requiert A100-80G ou 2xA100-40G)
+# GPU cible : RunPod A100-40G (40GB VRAM)
+# Usage : axolotl train training/suddenly-7b.yml
+
+base_model: mistralai/Mistral-7B-v0.3
+model_type: MistralForCausalLM
+tokenizer_type: LlamaTokenizer
+
+# --- Quantization ---
+load_in_4bit: true
+load_in_8bit: false
+bnb_config_kwargs:
+  bnb_4bit_quant_type: nf4
+  bnb_4bit_use_double_quant: true
+  bnb_4bit_compute_dtype: bfloat16
+
+# --- Adapter ---
+adapter: qlora
+lora_r: 64
+lora_alpha: 128
+lora_dropout: 0.05
+lora_target_linear: true
+lora_target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+
+# --- Dataset ---
+# Format : JSONL avec clé "messages", rôles system/user/assistant
+# Fichier produit par pipeline/formatting après anonymisation
+chat_template: mistral_v1
+datasets:
+  - path: data/corpus-rp-general.jsonl
+    type: chat_template
+    roles_to_train:
+      - assistant
+    train_on_eos: turn
+
+dataset_prepared_path: .cache/suddenly-7b-prepared
+val_set_size: 0.05
+
+# --- Séquences ---
+sequence_len: 4096
+sample_packing: true
+pad_to_sequence_len: true
+
+# --- Output ---
+output_dir: ./outputs/suddenly-7b
+
+# --- Entraînement ---
+num_epochs: 3
+micro_batch_size: 2
+gradient_accumulation_steps: 8
+# effective batch size = 2 * 8 = 16
+
+optimizer: adamw_bnb_8bit
+lr_scheduler: cosine
+learning_rate: 2.0e-4
+warmup_ratio: 0.05
+weight_decay: 0.01
+
+# --- Précision et mémoire ---
+bf16: auto
+tf32: false
+flash_attention: true
+gradient_checkpointing: true
+
+# --- Logging et checkpoints ---
+logging_steps: 10
+evals_per_epoch: 4
+saves_per_epoch: 1
+save_total_limit: 3
+
+# --- Stabilité ---
+loss_watchdog_threshold: 5.0
+loss_watchdog_patience: 3
+max_grad_norm: 1.0
+
+# --- Wandb (optionnel) ---
+# wandb_project: suddenly-ai-hub
+# wandb_entity:
+# wandb_name: suddenly-7b-run-1
+
+# --- Hub (optionnel, après entraînement) ---
+# hub_model_id: suddenly-ai/suddenly-7b
+# hub_strategy: end


### PR DESCRIPTION
## Summary

- Add `training/suddenly-7b.yml`: QLoRA config for Mistral 7B v0.3 base model (r=64, A100-40G)
- Add `training/suddenly-13b.yml`: QLoRA config for Mistral NeMo 12B base model (r=64, A100-40G)
- Add `training/lora-univers.yml`: template LoRA config for GROG universe axis (r=32, placeholders for genre/dataset/output)
- Add `training/lora-situation.yml`: template LoRA config for situation axis (r=16, placeholders)
- Add `training/scripts/runpod_train.sh`: RunPod launch script with HF auth, fallback Axolotl install, optional S3 upload

All configs use `type: chat_template` + `chat_template: mistral_v1` (compatible with data format from issue #9).
LoRA adapters generated via Axolotl (not mistral-finetune) for vLLM key name compatibility.

Closes #11