### PR TITLE
feat(gateway): endpoints FastAPI + routing LoRA fallback

### DIFF
--- a/gateway/adapter_router.py
+++ b/gateway/adapter_router.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from .config import get_config
+
+
+def resolve_adapter(genre: Optional[str], situation: Optional[str]) -> Optional[str]:
+    """Return adapter name for vLLM, or None to use the base model."""
+    adapters = get_config().available_adapters
+
+    candidates = []
+    if genre and situation:
+        candidates.append(f"lora-{genre}-{situation}")
+    if situation:
+        candidates.append(f"lora-{situation}")
+    if genre:
+        candidates.append(f"lora-{genre}")
+    candidates.append("lora-generique")
+
+    for name in candidates:
+        if name in adapters:
+            return name
+    return None

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Taxonomie statique — sera chargée dynamiquement depuis la DB en Phase 1
+# Genres = axe univers (GROG)
+# ---------------------------------------------------------------------------
+
+GENRES_DEFAULT: Final[list[str]] = [
+    "medieval-fantastique",
+    "historique-fantastique",
+    "scifi",
+    "contemporain-fantastique",
+    "space-opera",
+    "contemporain",
+    "post-apocalyptique",
+    "cyberpunk",
+    "super-heros",
+    "oriental-manga",
+    "generique",
+]
+
+SITUATIONS_DEFAULT: Final[list[str]] = [
+    "combat",
+    "exploration",
+    "dialogue",
+    "romance",
+    "intrigue",
+    "repos",
+    "voyage",
+]
+
+MODELS_DEFAULT: Final[list[str]] = [
+    "suddenly-7b",
+    "suddenly-13b",
+]
+
+
+@dataclass
+class GatewayConfig:
+    genres: list[str] = field(default_factory=lambda: list(GENRES_DEFAULT))
+    situations: list[str] = field(default_factory=lambda: list(SITUATIONS_DEFAULT))
+    models: list[str] = field(default_factory=lambda: list(MODELS_DEFAULT))
+    # Adapters réellement chargés dans vLLM (vide = aucun LoRA actif)
+    available_adapters: frozenset[str] = field(default_factory=frozenset)
+    vllm_base_url: str = field(default_factory=lambda: os.environ.get("VLLM_BASE_URL", "http://localhost:8001"))
+    default_model: str = "suddenly-7b"
+
+
+# Instance globale — remplacée au démarrage via lifespan ou dans les tests
+_config: GatewayConfig = GatewayConfig()
+
+
+def get_config() -> GatewayConfig:
+    return _config
+
+
+def set_config(cfg: GatewayConfig) -> None:
+    global _config
+    _config = cfg

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,8 +1,114 @@
-from fastapi import FastAPI
+from __future__ import annotations
 
-app = FastAPI()
+import uuid
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException
+
+from . import vllm_client
+from .adapter_router import resolve_adapter
+from .config import get_config
+from .models import (
+    ChatRequest,
+    ChatResponse,
+    ContributeRequest,
+    ContributeResponse,
+    HealthResponse,
+    ModelInfo,
+    ModelsResponse,
+    StatsResponse,
+)
 
 
-@app.get("/v1/health")
-def health():
-    return {"status": "ok"}
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+
+
+app = FastAPI(title="Suddenly AI Hub Gateway", lifespan=lifespan)
+
+
+def _validate_genre(genre: Optional[str]) -> None:
+    if genre is None:
+        return
+    valid = get_config().genres
+    if genre not in valid:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": f"Genre inconnu : {genre!r}", "valid_values": valid},
+        )
+
+
+def _validate_situation(situation: Optional[str]) -> None:
+    if situation is None:
+        return
+    valid = get_config().situations
+    if situation not in valid:
+        raise HTTPException(
+            status_code=422,
+            detail={"message": f"Situation inconnue : {situation!r}", "valid_values": valid},
+        )
+
+
+@app.post("/v1/chat/completions", response_model=ChatResponse)
+async def chat_completions(request: ChatRequest):
+    _validate_genre(request.genre)
+    _validate_situation(request.situation)
+    adapter = resolve_adapter(request.genre, request.situation)
+    try:
+        return await vllm_client.chat(request, adapter)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=502, detail=f"vLLM error: {exc.response.status_code}")
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=503, detail=f"vLLM unreachable: {exc}")
+
+
+@app.get("/v1/models", response_model=ModelsResponse)
+def list_models():
+    cfg = get_config()
+    return ModelsResponse(
+        data=[
+            ModelInfo(id=m, type="base", available_adapters=sorted(cfg.available_adapters))
+            for m in cfg.models
+        ]
+    )
+
+
+@app.get("/v1/health", response_model=HealthResponse)
+async def health():
+    cfg = get_config()
+    vllm_ok = False
+    try:
+        async with httpx.AsyncClient(base_url=cfg.vllm_base_url, timeout=5.0) as client:
+            resp = await client.get("/health")
+            vllm_ok = resp.is_success
+    except Exception:
+        pass
+    return HealthResponse(
+        status="ok" if vllm_ok else "degraded",
+        vllm_reachable=vllm_ok,
+        models_loaded=len(cfg.models) if vllm_ok else 0,
+    )
+
+
+@app.post("/v1/contribute", response_model=ContributeResponse)
+async def contribute(request: ContributeRequest):
+    _validate_genre(request.genre)
+    _validate_situation(request.situation)
+    return ContributeResponse(
+        accepted=True,
+        session_id=str(uuid.uuid4()),
+        message="Session reçue et mise en file d'attente.",
+    )
+
+
+@app.get("/v1/stats", response_model=StatsResponse)
+def stats():
+    cfg = get_config()
+    return StatsResponse(
+        models_available=len(cfg.models),
+        adapters_active=len(cfg.available_adapters),
+        sessions_contributed=0,
+    )

--- a/gateway/models.py
+++ b/gateway/models.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+class Message(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+class ChatRequest(BaseModel):
+    model: str = "suddenly-7b"
+    messages: list[Message] = Field(..., min_length=1)
+    genre: Optional[str] = None
+    situation: Optional[str] = None
+    max_tokens: int = Field(default=512, ge=1, le=4096)
+    temperature: float = Field(default=0.8, ge=0.0, le=2.0)
+    stream: bool = False
+
+
+class ChatChoice(BaseModel):
+    index: int
+    message: Message
+    finish_reason: Optional[str] = None
+
+
+class ChatUsage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class ChatResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    model: str
+    adapter_used: Optional[str] = None
+    choices: list[ChatChoice]
+    usage: ChatUsage
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/models
+# ---------------------------------------------------------------------------
+
+class ModelInfo(BaseModel):
+    id: str
+    type: Literal["base", "adapter"]
+    available_adapters: list[str] = Field(default_factory=list)
+
+
+class ModelsResponse(BaseModel):
+    object: str = "list"
+    data: list[ModelInfo]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/health
+# ---------------------------------------------------------------------------
+
+class HealthResponse(BaseModel):
+    status: Literal["ok", "degraded", "error"]
+    vllm_reachable: bool
+    models_loaded: int
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/contribute
+# ---------------------------------------------------------------------------
+
+class ContributeRequest(BaseModel):
+    messages: list[Message] = Field(..., min_length=2)
+    genre: Optional[str] = None
+    situation: Optional[str] = None
+    source_instance: str = Field(..., description="URL de l'instance Suddenly source")
+
+
+class ContributeResponse(BaseModel):
+    accepted: bool
+    session_id: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/stats
+# ---------------------------------------------------------------------------
+
+class StatsResponse(BaseModel):
+    models_available: int
+    adapters_active: int
+    sessions_contributed: int

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,2 +1,4 @@
 fastapi>=0.115,<1.0
 uvicorn[standard]>=0.32,<1.0
+httpx>=0.27,<1.0
+pydantic>=2.0,<3.0

--- a/gateway/vllm_client.py
+++ b/gateway/vllm_client.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+
+from .config import get_config
+from .models import ChatRequest, ChatChoice, ChatResponse, ChatUsage, Message
+
+
+async def chat(request: ChatRequest, adapter: Optional[str] = None) -> ChatResponse:
+    cfg = get_config()
+
+    payload: dict = {
+        "model": adapter if adapter else request.model,
+        "messages": [m.model_dump() for m in request.messages],
+        "max_tokens": request.max_tokens,
+        "temperature": request.temperature,
+        "stream": False,
+    }
+
+    async with httpx.AsyncClient(base_url=cfg.vllm_base_url, timeout=60.0) as client:
+        resp = await client.post("/v1/chat/completions", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+
+    choice = data["choices"][0]
+    return ChatResponse(
+        id=data["id"],
+        object="chat.completion",
+        model=request.model,
+        adapter_used=adapter,
+        choices=[
+            ChatChoice(
+                index=0,
+                message=Message(role="assistant", content=choice["message"]["content"]),
+                finish_reason=choice.get("finish_reason"),
+            )
+        ],
+        usage=ChatUsage(
+            prompt_tokens=data["usage"]["prompt_tokens"],
+            completion_tokens=data["usage"]["completion_tokens"],
+            total_tokens=data["usage"]["total_tokens"],
+        ),
+    )

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.adapter_router import resolve_adapter
+from gateway.config import GatewayConfig, set_config
+from gateway.main import app
+from gateway.models import ChatChoice, ChatResponse, ChatUsage, Message
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    cfg = GatewayConfig(
+        available_adapters=frozenset(["lora-cyberpunk", "lora-combat", "lora-generique"]),
+    )
+    set_config(cfg)
+    yield cfg
+    set_config(GatewayConfig())
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _fake_chat_response(adapter: str | None = None) -> ChatResponse:
+    return ChatResponse(
+        id="cmpl-test",
+        object="chat.completion",
+        model="suddenly-7b",
+        adapter_used=adapter,
+        choices=[
+            ChatChoice(
+                index=0,
+                message=Message(role="assistant", content="Réponse du MJ."),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+
+
+def _valid_chat_payload(**overrides) -> dict:
+    base = {
+        "model": "suddenly-7b",
+        "messages": [
+            {"role": "user", "content": "Le joueur entre dans la taverne."}
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# adapter_router
+# ---------------------------------------------------------------------------
+
+class TestAdapterRouter:
+    def test_both_genre_situation_merged_available(self):
+        set_config(GatewayConfig(available_adapters=frozenset(["lora-cyberpunk-combat"])))
+        assert resolve_adapter("cyberpunk", "combat") == "lora-cyberpunk-combat"
+
+    def test_fallback_to_situation(self):
+        set_config(GatewayConfig(available_adapters=frozenset(["lora-combat"])))
+        assert resolve_adapter("cyberpunk", "combat") == "lora-combat"
+
+    def test_fallback_to_genre(self):
+        set_config(GatewayConfig(available_adapters=frozenset(["lora-cyberpunk"])))
+        assert resolve_adapter("cyberpunk", "combat") == "lora-cyberpunk"
+
+    def test_fallback_to_generique(self):
+        set_config(GatewayConfig(available_adapters=frozenset(["lora-generique"])))
+        assert resolve_adapter("cyberpunk", "combat") == "lora-generique"
+
+    def test_fallback_to_base_model(self):
+        set_config(GatewayConfig(available_adapters=frozenset()))
+        assert resolve_adapter("cyberpunk", "combat") is None
+
+    def test_no_genre_no_situation_generique(self):
+        set_config(GatewayConfig(available_adapters=frozenset(["lora-generique"])))
+        assert resolve_adapter(None, None) == "lora-generique"
+
+    def test_no_genre_no_situation_base(self):
+        set_config(GatewayConfig(available_adapters=frozenset()))
+        assert resolve_adapter(None, None) is None
+
+    def test_situation_only(self):
+        set_config(GatewayConfig(available_adapters=frozenset(["lora-combat"])))
+        assert resolve_adapter(None, "combat") == "lora-combat"
+
+    def test_genre_only(self):
+        set_config(GatewayConfig(available_adapters=frozenset(["lora-scifi"])))
+        assert resolve_adapter("scifi", None) == "lora-scifi"
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/health
+# ---------------------------------------------------------------------------
+
+class TestHealth:
+    def test_vllm_unreachable(self, client):
+        mock_cls = MagicMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        with patch("gateway.main.httpx.AsyncClient", mock_cls):
+            resp = client.get("/v1/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "degraded"
+        assert data["vllm_reachable"] is False
+        assert data["models_loaded"] == 0
+
+    def test_vllm_reachable(self, client):
+        mock_resp = MagicMock()
+        mock_resp.is_success = True
+        mock_inner = AsyncMock()
+        mock_inner.get = AsyncMock(return_value=mock_resp)
+        mock_cls = MagicMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_inner)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        with patch("gateway.main.httpx.AsyncClient", mock_cls):
+            resp = client.get("/v1/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["vllm_reachable"] is True
+        assert data["models_loaded"] > 0
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/models
+# ---------------------------------------------------------------------------
+
+class TestModels:
+    def test_returns_configured_models(self, client):
+        resp = client.get("/v1/models")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "list"
+        ids = [m["id"] for m in data["data"]]
+        assert "suddenly-7b" in ids
+        assert "suddenly-13b" in ids
+
+    def test_adapters_listed(self, client):
+        resp = client.get("/v1/models")
+        for model in resp.json()["data"]:
+            assert "lora-generique" in model["available_adapters"]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/stats
+# ---------------------------------------------------------------------------
+
+class TestStats:
+    def test_returns_stats(self, client):
+        resp = client.get("/v1/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["models_available"] == 2
+        assert data["adapters_active"] == 3
+        assert data["sessions_contributed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+class TestChatCompletions:
+    def test_valid_request(self, client):
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock) as mock_chat:
+            mock_chat.return_value = _fake_chat_response()
+            resp = client.post("/v1/chat/completions", json=_valid_chat_payload())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["choices"][0]["message"]["role"] == "assistant"
+
+    def test_unknown_genre_returns_422(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json=_valid_chat_payload(genre="fantasy-unknown"),
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "valid_values" in detail
+
+    def test_unknown_situation_returns_422(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json=_valid_chat_payload(situation="unknown-situation"),
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "valid_values" in detail
+
+    def test_valid_genre_and_situation(self, client):
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock) as mock_chat:
+            mock_chat.return_value = _fake_chat_response("lora-combat")
+            resp = client.post(
+                "/v1/chat/completions",
+                json=_valid_chat_payload(genre="cyberpunk", situation="combat"),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["adapter_used"] == "lora-combat"
+
+    def test_vllm_http_error_returns_502(self, client):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock) as mock_chat:
+            mock_chat.side_effect = httpx.HTTPStatusError("err", request=MagicMock(), response=mock_resp)
+            resp = client.post("/v1/chat/completions", json=_valid_chat_payload())
+        assert resp.status_code == 502
+
+    def test_vllm_connect_error_returns_503(self, client):
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock) as mock_chat:
+            mock_chat.side_effect = httpx.ConnectError("refused")
+            resp = client.post("/v1/chat/completions", json=_valid_chat_payload())
+        assert resp.status_code == 503
+
+    def test_no_messages_returns_422(self, client):
+        resp = client.post("/v1/chat/completions", json={"model": "suddenly-7b", "messages": []})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/contribute
+# ---------------------------------------------------------------------------
+
+class TestContribute:
+    def _valid_payload(self, **overrides) -> dict:
+        base = {
+            "messages": [
+                {"role": "user", "content": "action"},
+                {"role": "assistant", "content": "réponse MJ"},
+            ],
+            "source_instance": "https://rp.example.com",
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_contribution(self, client):
+        resp = client.post("/v1/contribute", json=self._valid_payload())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["accepted"] is True
+        assert "session_id" in data
+
+    def test_each_session_gets_unique_id(self, client):
+        ids = {client.post("/v1/contribute", json=self._valid_payload()).json()["session_id"] for _ in range(3)}
+        assert len(ids) == 3
+
+    def test_unknown_genre_returns_422(self, client):
+        resp = client.post("/v1/contribute", json=self._valid_payload(genre="unknown"))
+        assert resp.status_code == 422
+
+    def test_unknown_situation_returns_422(self, client):
+        resp = client.post("/v1/contribute", json=self._valid_payload(situation="unknown"))
+        assert resp.status_code == 422
+
+    def test_single_message_rejected(self, client):
+        payload = self._valid_payload()
+        payload["messages"] = [{"role": "user", "content": "seul"}]
+        resp = client.post("/v1/contribute", json=payload)
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Squelette complet de la gateway FastAPI avec 5 endpoints (`/v1/chat/completions`, `/v1/models`, `/v1/health`, `/v1/contribute`, `/v1/stats`)
- `GatewayConfig` dataclass pour la taxonomie dynamique genres/situations/adapters
- `resolve_adapter()` avec logique de fallback en 5 niveaux : `lora-{univers}-{situation}` → `lora-{situation}` → `lora-{univers}` → `lora-generique` → modèle de base
- Client async `httpx` vers vLLM backend
- Validation genre/situation HTTP 422 avec liste des valeurs acceptées

## Test plan

- [x] 26 tests couvrant routing d'adapter, validation des champs, gestion d'erreurs vLLM (502/503)
- [x] Tous les tests passent : `pytest tests/test_gateway.py`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)