### PR TITLE
feat(gateway): authentification ActivityPub HTTP Signatures

### DIFF
--- a/gateway/auth.py
+++ b/gateway/auth.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import base64
+import re
+from typing import Any
+
+import httpx
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from fastapi import HTTPException, Request
+
+_key_cache: dict[str, Any] = {}
+
+_SIG_PARAM_RE = re.compile(r'(\w+)="([^"]*)"')
+
+_REQUIRED_FIELDS = {"keyId", "headers", "signature"}
+
+
+def parse_signature_header(header: str) -> dict[str, str]:
+    params = dict(_SIG_PARAM_RE.findall(header))
+    missing = _REQUIRED_FIELDS - params.keys()
+    if missing:
+        raise ValueError(f"Missing Signature fields: {missing}")
+    return params
+
+
+async def fetch_public_key(key_id: str):
+    if key_id in _key_cache:
+        return _key_cache[key_id]
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(key_id, headers={"Accept": "application/activity+json"})
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+        raise HTTPException(status_code=502, detail=f"Cannot fetch keyId: {exc}") from exc
+
+    pem = (data.get("publicKey") or {}).get("publicKeyPem")
+    if not pem:
+        raise HTTPException(status_code=502, detail="Missing publicKey.publicKeyPem")
+
+    try:
+        public_key = serialization.load_pem_public_key(pem.encode())
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Invalid PEM key: {exc}") from exc
+
+    _key_cache[key_id] = public_key
+    return public_key
+
+
+def build_signing_string(headers_list: list[str], request_headers: dict, method: str, path: str) -> str:
+    lines = []
+    for name in headers_list:
+        if name == "(request-target)":
+            lines.append(f"(request-target): {method.lower()} {path}")
+        else:
+            value = request_headers.get(name.lower())
+            if value is None:
+                raise ValueError(f"Header listed in Signature but missing from request: {name!r}")
+            lines.append(f"{name}: {value}")
+    return "\n".join(lines)
+
+
+def verify_rsa_sha256(public_key, signing_string: str, signature_b64: str) -> None:
+    sig_bytes = base64.b64decode(signature_b64)
+    public_key.verify(sig_bytes, signing_string.encode(), padding.PKCS1v15(), hashes.SHA256())
+
+
+def preload_key(key_id: str, public_key) -> None:
+    _key_cache[key_id] = public_key
+
+
+def clear_key_cache() -> None:
+    _key_cache.clear()
+
+
+async def verify_http_signature(request: Request) -> None:
+    header = request.headers.get("signature")
+    if not header:
+        raise HTTPException(status_code=401, detail="Missing Signature header")
+
+    try:
+        sig_params = parse_signature_header(header)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Malformed Signature header: {exc}") from exc
+
+    headers_list = sig_params["headers"].split()
+    method = request.method
+    path = request.url.path
+    if request.url.query:
+        path = f"{path}?{request.url.query}"
+
+    request_headers = dict(request.headers)
+
+    try:
+        signing_string = build_signing_string(headers_list, request_headers, method, path)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    public_key = await fetch_public_key(sig_params["keyId"])
+
+    try:
+        verify_rsa_sha256(public_key, signing_string, sig_params["signature"])
+    except InvalidSignature as exc:
+        raise HTTPException(status_code=401, detail="Invalid HTTP signature") from exc

--- a/gateway/auth.py
+++ b/gateway/auth.py
@@ -26,6 +26,8 @@ def parse_signature_header(header: str) -> dict[str, str]:
 
 
 async def fetch_public_key(key_id: str):
+    if not key_id.startswith("https://"):
+        raise HTTPException(status_code=400, detail="keyId must use HTTPS")
     if key_id in _key_cache:
         return _key_cache[key_id]
     try:
@@ -58,7 +60,7 @@ def build_signing_string(headers_list: list[str], request_headers: dict, method:
             value = request_headers.get(name.lower())
             if value is None:
                 raise ValueError(f"Header listed in Signature but missing from request: {name!r}")
-            lines.append(f"{name}: {value}")
+            lines.append(f"{name.lower()}: {value}")
     return "\n".join(lines)
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -48,6 +48,12 @@ class GatewayConfig:
     available_adapters: frozenset[str] = field(default_factory=frozenset)
     vllm_base_url: str = field(default_factory=lambda: os.environ.get("VLLM_BASE_URL", "http://localhost:8001"))
     default_model: str = "suddenly-7b"
+    activitypub_mock: bool = field(
+        default_factory=lambda: os.environ.get("ACTIVITYPUB_MOCK", "false").lower() == "true"
+    )
+    mock_instance_url: str = field(
+        default_factory=lambda: os.environ.get("MOCK_INSTANCE_URL", "http://mock-instance:8080")
+    )
 
 
 # Instance globale — remplacée au démarrage via lifespan ou dans les tests

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -5,10 +5,12 @@ from contextlib import asynccontextmanager
 from typing import Optional
 
 import httpx
-from fastapi import FastAPI, HTTPException
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import Depends, FastAPI, HTTPException
 
 from . import vllm_client
 from .adapter_router import resolve_adapter
+from .auth import clear_key_cache, preload_key, verify_http_signature
 from .config import get_config
 from .models import (
     ChatRequest,
@@ -24,7 +26,16 @@ from .models import (
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    cfg = get_config()
+    if cfg.activitypub_mock:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        public_key = private_key.public_key()
+        mock_key_id = f"{cfg.mock_instance_url}/actor#main-key"
+        preload_key(mock_key_id, public_key)
+        app.state.mock_private_key = private_key
+        app.state.mock_key_id = mock_key_id
     yield
+    clear_key_cache()
 
 
 app = FastAPI(title="Suddenly AI Hub Gateway", lifespan=lifespan)
@@ -53,7 +64,10 @@ def _validate_situation(situation: Optional[str]) -> None:
 
 
 @app.post("/v1/chat/completions", response_model=ChatResponse)
-async def chat_completions(request: ChatRequest):
+async def chat_completions(
+    request: ChatRequest,
+    _: None = Depends(verify_http_signature),
+):
     _validate_genre(request.genre)
     _validate_situation(request.situation)
     adapter = resolve_adapter(request.genre, request.situation)
@@ -94,7 +108,10 @@ async def health():
 
 
 @app.post("/v1/contribute", response_model=ContributeResponse)
-async def contribute(request: ContributeRequest):
+async def contribute(
+    request: ContributeRequest,
+    _: None = Depends(verify_http_signature),
+):
     _validate_genre(request.genre)
     _validate_situation(request.situation)
     return ContributeResponse(

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.115,<1.0
 uvicorn[standard]>=0.32,<1.0
 httpx>=0.27,<1.0
 pydantic>=2.0,<3.0
+cryptography>=43,<45

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from fastapi.testclient import TestClient
+
+from gateway.auth import (
+    build_signing_string,
+    clear_key_cache,
+    parse_signature_header,
+    preload_key,
+    verify_rsa_sha256,
+)
+from gateway.main import app
+
+
+# ---------------------------------------------------------------------------
+# Module-scope RSA key pair
+# ---------------------------------------------------------------------------
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PUBLIC_KEY = _PRIVATE_KEY.public_key()
+_KEY_ID = "https://rp.example.com/actor#main-key"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sign(signing_string: str) -> str:
+    sig = _PRIVATE_KEY.sign(signing_string.encode(), padding.PKCS1v15(), hashes.SHA256())
+    return base64.b64encode(sig).decode()
+
+
+def _make_sig_header(headers_list: list[str], signing_string: str) -> str:
+    sig_b64 = _sign(signing_string)
+    headers_str = " ".join(headers_list)
+    return f'keyId="{_KEY_ID}",algorithm="rsa-sha256",headers="{headers_str}",signature="{sig_b64}"'
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_key_cache()
+    yield
+    clear_key_cache()
+
+
+@pytest.fixture
+def client():
+    preload_key(_KEY_ID, _PUBLIC_KEY)
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# parse_signature_header
+# ---------------------------------------------------------------------------
+
+class TestParseSignatureHeader:
+    def test_valid_header(self):
+        hdr = 'keyId="https://example.com/actor#key",algorithm="rsa-sha256",headers="(request-target) date",signature="abc123"'
+        params = parse_signature_header(hdr)
+        assert params["keyId"] == "https://example.com/actor#key"
+        assert params["algorithm"] == "rsa-sha256"
+        assert params["headers"] == "(request-target) date"
+        assert params["signature"] == "abc123"
+
+    def test_missing_key_id_raises(self):
+        hdr = 'algorithm="rsa-sha256",headers="date",signature="abc"'
+        with pytest.raises(ValueError, match="keyId"):
+            parse_signature_header(hdr)
+
+    def test_missing_headers_raises(self):
+        hdr = 'keyId="https://example.com/actor#key",signature="abc"'
+        with pytest.raises(ValueError, match="headers"):
+            parse_signature_header(hdr)
+
+    def test_missing_signature_raises(self):
+        hdr = 'keyId="https://example.com/actor#key",headers="date"'
+        with pytest.raises(ValueError, match="signature"):
+            parse_signature_header(hdr)
+
+
+# ---------------------------------------------------------------------------
+# build_signing_string
+# ---------------------------------------------------------------------------
+
+class TestBuildSigningString:
+    def test_request_target(self):
+        result = build_signing_string(["(request-target)"], {}, "POST", "/v1/chat/completions")
+        assert result == "(request-target): post /v1/chat/completions"
+
+    def test_regular_header(self):
+        result = build_signing_string(["date"], {"date": "Thu, 01 May 2026 12:00:00 GMT"}, "POST", "/v1/chat/completions")
+        assert result == "date: Thu, 01 May 2026 12:00:00 GMT"
+
+    def test_missing_header_raises(self):
+        with pytest.raises(ValueError, match="date"):
+            build_signing_string(["date"], {}, "POST", "/v1/chat/completions")
+
+    def test_multiple_headers_joined_by_newline(self):
+        result = build_signing_string(
+            ["(request-target)", "date"],
+            {"date": "Thu, 01 May 2026 12:00:00 GMT"},
+            "POST",
+            "/v1/chat/completions",
+        )
+        lines = result.split("\n")
+        assert len(lines) == 2
+        assert lines[0] == "(request-target): post /v1/chat/completions"
+        assert lines[1] == "date: Thu, 01 May 2026 12:00:00 GMT"
+
+
+# ---------------------------------------------------------------------------
+# verify_rsa_sha256
+# ---------------------------------------------------------------------------
+
+class TestVerifyRsaSha256:
+    def test_valid_signature_passes(self):
+        msg = "test signing string"
+        sig_b64 = _sign(msg)
+        verify_rsa_sha256(_PUBLIC_KEY, msg, sig_b64)  # no exception
+
+    def test_invalid_signature_raises(self):
+        msg = "test signing string"
+        bad_sig = base64.b64encode(b"invalide" * 32).decode()
+        with pytest.raises(InvalidSignature):
+            verify_rsa_sha256(_PUBLIC_KEY, msg, bad_sig)
+
+    def test_wrong_key_raises(self):
+        msg = "test signing string"
+        other_private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        sig_b64 = base64.b64encode(
+            other_private.sign(msg.encode(), padding.PKCS1v15(), hashes.SHA256())
+        ).decode()
+        with pytest.raises(InvalidSignature):
+            verify_rsa_sha256(_PUBLIC_KEY, msg, sig_b64)
+
+
+# ---------------------------------------------------------------------------
+# verify_http_signature (intégration via TestClient)
+# ---------------------------------------------------------------------------
+
+class TestVerifyHttpSignatureDependency:
+    def _make_request(self, client, signing_string: str, headers_list: list[str], extra_headers: dict | None = None) -> object:
+        sig_header = _make_sig_header(headers_list, signing_string)
+        headers = {"signature": sig_header, "content-type": "application/json"}
+        if extra_headers:
+            headers.update(extra_headers)
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock) as mock_chat:
+            from gateway.models import ChatChoice, ChatResponse, ChatUsage, Message
+            mock_chat.return_value = ChatResponse(
+                id="cmpl-test",
+                object="chat.completion",
+                model="suddenly-7b",
+                adapter_used=None,
+                choices=[ChatChoice(index=0, message=Message(role="assistant", content="ok"), finish_reason="stop")],
+                usage=ChatUsage(prompt_tokens=5, completion_tokens=5, total_tokens=10),
+            )
+            return client.post(
+                "/v1/chat/completions",
+                json={"model": "suddenly-7b", "messages": [{"role": "user", "content": "action"}]},
+                headers=headers,
+            )
+
+    def test_missing_signature_header_returns_401(self, client):
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock):
+            resp = client.post(
+                "/v1/chat/completions",
+                json={"model": "suddenly-7b", "messages": [{"role": "user", "content": "action"}]},
+            )
+        assert resp.status_code == 401
+
+    def test_malformed_signature_header_returns_400(self, client):
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock):
+            resp = client.post(
+                "/v1/chat/completions",
+                json={"model": "suddenly-7b", "messages": [{"role": "user", "content": "action"}]},
+                headers={"signature": "not=valid,garbage"},
+            )
+        assert resp.status_code == 400
+
+    def test_valid_signature_returns_200(self, client):
+        signing_string = "(request-target): post /v1/chat/completions"
+        resp = self._make_request(client, signing_string, ["(request-target)"])
+        assert resp.status_code == 200
+
+    def test_invalid_signature_returns_401(self, client):
+        bad_sig = base64.b64encode(b"invalide" * 32).decode()
+        sig_header = f'keyId="{_KEY_ID}",algorithm="rsa-sha256",headers="(request-target)",signature="{bad_sig}"'
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock):
+            resp = client.post(
+                "/v1/chat/completions",
+                json={"model": "suddenly-7b", "messages": [{"role": "user", "content": "action"}]},
+                headers={"signature": sig_header, "content-type": "application/json"},
+            )
+        assert resp.status_code == 401
+
+    def test_missing_listed_header_returns_400(self, client):
+        signing_string = "(request-target): post /v1/chat/completions"
+        sig_header = _make_sig_header(["(request-target)", "date"], signing_string)
+        with patch("gateway.main.vllm_client.chat", new_callable=AsyncMock):
+            resp = client.post(
+                "/v1/chat/completions",
+                json={"model": "suddenly-7b", "messages": [{"role": "user", "content": "action"}]},
+                headers={"signature": sig_header, "content-type": "application/json"},
+                # note: no "date" header sent
+            )
+        assert resp.status_code == 400

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gateway.adapter_router import resolve_adapter
-from gateway.auth import verify_http_signature
+from gateway.auth import clear_key_cache, verify_http_signature
 from gateway.config import GatewayConfig, set_config
 from gateway.main import app
 from gateway.models import ChatChoice, ChatResponse, ChatUsage, Message
@@ -19,6 +19,7 @@ from gateway.models import ChatChoice, ChatResponse, ChatUsage, Message
 
 @pytest.fixture(autouse=True)
 def reset_config():
+    clear_key_cache()
     cfg = GatewayConfig(
         available_adapters=frozenset(["lora-cyberpunk", "lora-combat", "lora-generique"]),
     )
@@ -28,6 +29,7 @@ def reset_config():
     yield cfg
     app.dependency_overrides.pop(verify_http_signature, None)
     set_config(GatewayConfig())
+    clear_key_cache()
 
 
 @pytest.fixture

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gateway.adapter_router import resolve_adapter
+from gateway.auth import verify_http_signature
 from gateway.config import GatewayConfig, set_config
 from gateway.main import app
 from gateway.models import ChatChoice, ChatResponse, ChatUsage, Message
@@ -22,7 +23,10 @@ def reset_config():
         available_adapters=frozenset(["lora-cyberpunk", "lora-combat", "lora-generique"]),
     )
     set_config(cfg)
+    # Désactive la vérification de signature pour les tests existants
+    app.dependency_overrides[verify_http_signature] = lambda: None
     yield cfg
+    app.dependency_overrides.pop(verify_http_signature, None)
     set_config(GatewayConfig())
 
 


### PR DESCRIPTION
## Summary

- `gateway/auth.py` : parsing header `Signature`, fetch clé publique ActivityPub (cache en mémoire), construction du signing-string, vérification RSA-SHA256, dépendance FastAPI `verify_http_signature`
- `POST /v1/chat/completions` et `POST /v1/contribute` protégés par `Depends(verify_http_signature)`
- `GatewayConfig` : ajout `activitypub_mock` + `mock_instance_url` pour le mode développement
- Lifespan : pré-charge une paire RSA éphémère si `activitypub_mock=True`
- Protection SSRF : `keyId` doit commencer par `https://`
- Conformité spec draft-cavage-http-signatures-12 (noms de headers lowercase dans le signing-string)

## Test plan

- [x] 16 tests unitaires + intégration dans `tests/test_auth.py`
- [x] 26 tests `tests/test_gateway.py` préservés via dependency override
- [x] Total : 42/42 tests passent

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)