### PR TITLE
docs(architecture): formalize tables+ML pivot (4 stages, 4 granularity levels)

### DIFF
--- a/aidd_docs/memory/architecture-tables-ml.md
+++ b/aidd_docs/memory/architecture-tables-ml.md
@@ -35,7 +35,7 @@ L'approche initiale (LLM fine-tuné + LoRA stacking sur 3 axes — univers, situ
 
 Une **table** = ensemble de lignes typées au même niveau, partageant un slot d'usage (ex: « gestes de combat médiéval », « beats de romance »).
 
-Chaque table porte des **tags** sur les 3 axes existants (univers, situation, voix). Le sélecteur (étage 1) filtre par tags avant tirage — pas d'explosion combinatoire de jeux de tables.
+Chaque table porte des **tags** sur les cinq axes canoniques (`univers`, `situation`, `rapport_initial`, `voix`, `emotion_dominante` — cf. `philosophy.md` § Conventions). Le sélecteur (étage 1) filtre par tags avant tirage — pas d'explosion combinatoire de jeux de tables.
 
 ## Pipeline de génération — 4 étages
 
@@ -134,16 +134,18 @@ Le pipeline d'analyse est volontairement spécifié à un niveau d'abstraction s
 
 ## Carte de couverture contextuelle
 
-Artefact structurel maintenu par le service Muses : tableau indexé par `(univers × situation × voix)` qui agrège, par cellule contextuelle :
+Artefact structurel maintenu par le service Muses : hypercube indexé par `(univers × situation × rapport_initial × voix × emotion_dominante)` qui agrège, par cellule contextuelle :
 
 - nombre de rows par niveau (entités, templates, beats, fragments),
 - nombre d'auteurs distincts trusted ayant contribué dans cette cellule,
 - date de la dernière contribution.
 
+L'espace est plus grand qu'avec 3 axes (~10× selon les cardinalités), donc plus de cellules vides — c'est attendu et c'est précisément ce qui rend le diagnostic et le fallback utiles. La représentation reste sparse : on ne stocke que les cellules effectivement peuplées.
+
 Usage :
 
 - **Diagnostic** — repérer les zones creuses et prioriser le mining bootstrap ou la sollicitation de contributions.
-- **Fallback hiérarchique** — quand la cellule cible est sous-peuplée, l'étage 1 (sélecteur) peut tomber gracieusement sur une cellule voisine (un axe relâché à la fois : voix → situation → univers).
+- **Fallback hiérarchique** — quand la cellule cible est sous-peuplée, l'étage 1 (sélecteur) peut tomber gracieusement sur une cellule voisine, en relâchant un axe à la fois dans cet ordre du plus local au plus fondamental : `emotion_dominante → voix → rapport_initial → situation → univers`. Le relâchement s'arrête dès qu'une cellule atteint un seuil de peuplement suffisant.
 - **Décision MVP** — sélection des cellules à servir en priorité v1.
 
 La carte est référencée dans `learning-and-trust.md` §6 comme garde-fou anti-cold-start.
@@ -190,4 +192,4 @@ Chacun de ces points fera l'objet d'un document dédié.
 2. **Cible MVP** — bien que le périmètre vise toutes les features, sur laquelle valider le pipeline end-to-end en premier ? (proposition par défaut : `suggestion de dialogue` #77, niveau fragments + entités, le plus simple.)
 3. **Seuil d'activation du filtre** — un best-of-N nécessite N candidats minimum ; pour les features où la base de tables est encore petite, fallback à top-1 du recombinateur ?
 
-Choix précédemment ouverts et désormais actés : tagging axial plutôt que jeux de tables séparés (cf. niveaux de granularité §3) ; axes canoniques `univers / situation / voix` (cf. `philosophy.md` § Conventions).
+Choix précédemment ouverts et désormais actés : tagging axial plutôt que jeux de tables séparés (cf. niveaux de granularité §3) ; cinq axes canoniques atomiques `univers / situation / rapport_initial / voix / emotion_dominante` (cf. `philosophy.md` § Conventions).

--- a/aidd_docs/memory/architecture-tables-ml.md
+++ b/aidd_docs/memory/architecture-tables-ml.md
@@ -1,0 +1,167 @@
+---
+name: architecture-tables-ml
+description: Architecture du pivot vers algorithme de tirage sur tables aléatoires assisté par ML
+---
+
+# Architecture — Tables aléatoires + ML
+
+## Contexte du pivot
+
+L'approche initiale (LLM fine-tuné + LoRA stacking sur 3 axes — univers, situation, voix) est abandonnée.
+
+**Causes** :
+
+- Volume de corpus insuffisant pour atteindre une qualité acceptable par fine-tune (seuil 500 sessions/genre jamais atteint).
+- Dépendance GPU/inférence non tenable économiquement.
+
+**Nouvelle mécanique** : un algorithme de choix tire dans des tables curées (au sens JdR), et un pipeline ML rend ces tirages contextuels au lieu d'uniformes. Le périmètre fonctionnel défini dans `external/use-cases.md` reste intact (features #77–#89) ; seul le moyen change.
+
+## Principes directeurs
+
+1. **Aucune génération de tokens** — toute sortie est composée à partir de lignes de tables existantes.
+2. **Tirage non-uniforme** — chaque tirage est pondéré par le contexte via un modèle ML léger.
+3. **Explicabilité** — chaque sortie est traçable jusqu'aux lignes tirées et aux scores des étages.
+4. **CPU-only** — classifieurs, embeddings, rerankers de petite taille (distillation, sentence-transformers).
+5. **Asymétrie génération / analyse** — génération = tirage *depuis* une table ; analyse = projection *sur* une table de patterns.
+
+## Les 4 niveaux de granularité de tables
+
+| Niveau                  | Contenu                                  | Exemples                                                 | Usage                                                |
+| ----------------------- | ---------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
+| **Entités atomiques**   | unités lexicales typées                  | gestes, émotions, lieux, objets, noms, traits            | remplissage de slots, briques pour niveaux supérieurs |
+| **Templates à trous**   | squelettes paramétrés                    | « {char} {geste} en {émotion}, {action_suite} »          | structure de phrase ; slots typés tirent dans les entités |
+| **Beats narratifs**     | unités de niveau scène                   | « hésitation », « rupture de ton », « révélation »        | décident QUOI dire avant de décider COMMENT          |
+| **Fragments narratifs** | sorties complètes prêtes à l'emploi      | répliques / phrases curées depuis corpus                 | échantillonnés directement si beat + contexte alignés |
+
+Une **table** = ensemble de lignes typées au même niveau, partageant un slot d'usage (ex: « gestes de combat médiéval », « beats de romance »).
+
+Chaque table porte des **tags** sur les 3 axes existants (univers, situation, voix). Le sélecteur (étage 1) filtre par tags avant tirage — pas d'explosion combinatoire de jeux de tables.
+
+## Pipeline de génération — 4 étages
+
+```mermaid
+---
+title: Pipeline de génération table-based
+---
+flowchart TD
+    Context["Contexte: perso, scène, derniers reports, feature"]
+    Selector["Étage 1 — Sélecteur"]
+    Weighter["Étage 2 — Pondérateur"]
+    Recombiner["Étage 3 — Recombinateur"]
+    Filter["Étage 4 — Filtreur"]
+    Output["Sortie retenue + alternatives"]
+    TablePool["Pool de tables curées et extraites du corpus"]
+
+    Context --> Selector
+    Selector -- "shortlist de tables" --> Weighter
+    Weighter -- "tables avec distribution apprise" --> Recombiner
+    Recombiner -- "N candidats" --> Filter
+    Filter --> Output
+    TablePool -.-> Selector
+    TablePool -.-> Weighter
+```
+
+### Étage 1 — Sélecteur
+
+- **Rôle** : choisir le sous-ensemble de tables pertinentes pour la feature et le contexte.
+- **Entrée** : embedding du contexte + tags axiaux + feature demandée.
+- **Modèle** : classifieur multi-label léger (logistic regression ou petit MLP sur embeddings).
+- **Sortie** : shortlist de N tables avec score de pertinence (typiquement N = 3 à 8).
+
+### Étage 2 — Pondérateur
+
+- **Rôle** : pour chaque table shortlistée, transformer la distribution uniforme en distribution apprise (les lignes les plus pertinentes au contexte ont une probabilité plus haute).
+- **Modèle** : reranker cross-encoder léger OU similarité d'embeddings contexte ↔ ligne, normalisée en softmax.
+- **Sortie** : pour chaque table, vecteur de probabilités sur ses lignes.
+
+### Étage 3 — Recombinateur
+
+- **Rôle** : tirer K échantillons par étage de granularité (beat → template → slots remplis depuis entités) et les assembler en N candidats de sortie textuelle.
+- **Modèle** : règles d'assemblage déterministes pour les cas simples, petit modèle séquentiel optionnel pour le sequencing complexe.
+- **Sortie** : N candidats (typiquement N = 5 à 10).
+
+### Étage 4 — Filtreur
+
+- **Rôle** : scoring best-of-N. Évaluer cohérence de chaque candidat avec contexte, style, voix.
+- **Modèle** : cross-encoder (contexte ↔ candidat) entraîné sur l'historique accept/reject utilisateur.
+- **Sortie** : 1 candidat retenu, top-2 et top-3 gardés pour variations / fallback UI.
+
+## Mapping feature → niveaux exploités
+
+| Feature                              | Niveaux dominants                            | Étages actifs                                                 |
+| ------------------------------------ | -------------------------------------------- | ------------------------------------------------------------- |
+| Suggestion dialogue (#77)            | fragments + entités                          | tous (emphase fragments)                                      |
+| Suggestion action (#78)              | beats + templates + entités                  | tous (recombinateur central)                                  |
+| Suggestion description (#79)         | templates + entités (lieux/ambiances)        | tous                                                          |
+| Suggestion pensée intérieure (#80)   | beats + templates + entités                  | tous                                                          |
+| Export prompt vidéo (#89)            | templates visuels + entités                  | sélecteur + pondérateur + recombinateur (canevas fixe, pas de filtre best-of-N) |
+
+## Pipeline d'analyse — projection inversée
+
+Pour les features d'analyse, les tables deviennent des **catalogues de patterns**. Le contenu utilisateur est projeté dessus pour produire un rapport, au lieu de tirer pour produire du texte.
+
+```mermaid
+---
+title: Pipeline d'analyse par projection
+---
+flowchart TD
+    Content["Contenu utilisateur: scène ou session"]
+    Embedder["Embedder"]
+    PatternTables["Tables de patterns: incohérences, archétypes, arcs canoniques"]
+    Matcher["Matcher / Classifieur"]
+    Aggregator["Agrégateur de signaux"]
+    Report["Rapport: scores + lignes matchées + suggestions"]
+
+    Content --> Embedder
+    Embedder --> Matcher
+    PatternTables -.-> Matcher
+    Matcher --> Aggregator
+    Aggregator --> Report
+```
+
+| Feature                          | Tables de patterns                                      | Mécanisme                                                  |
+| -------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------- |
+| Cohérence scène (#81)            | types d'incohérence (caractère/ton), beats canoniques   | classification multi-label par fragment de scène           |
+| Cohérence session (#82)          | arcs narratifs canoniques, archétypes personnage        | matching séquentiel de beats + scoring d'arc               |
+| Résumé de session (#83)          | templates de résumé tagués genre/situation              | extraction de beats par projection + remplissage du template |
+| Suggestions liens fédérés (#84)  | embeddings des personnages publics de l'instance        | similarité d'embeddings + seuil                            |
+
+## Provenance des tables
+
+Trois voies d'alimentation à combiner :
+
+1. **Mining corpus → clustering → tables candidates**
+   - S'appuie sur `pipelines/anonymization/` et `pipelines/crawl_rpv/` (déjà présents).
+   - Extraction NER, segmentation en beats, dédup + clustering sémantique des fragments.
+   - Génère des tables candidates à fort volume mais bruitées.
+2. **Curation manuelle**
+   - Validation / nettoyage / ajout d'entrées.
+   - Versionnée en git, format JSONL ou YAML diff-friendly.
+3. **Boucle de rétroaction utilisateur**
+   - Accept → renforce la combinaison (ligne tirée, contexte d'appel).
+   - Reject ou édition → signal négatif ; édition capturée comme candidat fragment.
+   - Alimente le ré-entraînement des étages 1, 2, 4.
+
+## Format de stockage (proposition)
+
+- 1 fichier JSONL par table, versionné en git.
+- Index SQLite avec FTS5 et colonnes de tags pour query rapide.
+- Embeddings pré-calculés des lignes en `.npy` à côté de chaque JSONL.
+- Pas de DB serveur pour le MVP — tout sur disque, déployable en read-only.
+
+## Hors périmètre de ce document
+
+- Choix précis des modèles ML (à figer en POC).
+- Schéma détaillé des tables (champ par champ).
+- Pipeline de fabrication des tables depuis le corpus existant.
+- Refonte de la grille tarifaire Muses (l'inférence quasi gratuite invalide la grille actuelle de `use-cases.md` §1.2).
+- Réécriture de la doc périmée (`README.md`, `architecture.md`, `project_brief.md`, `codebase_map.md`).
+
+Chacun de ces points fera l'objet d'un document dédié.
+
+## Questions ouvertes à acter
+
+1. **Tagging vs jeux de tables séparés** — confirmer le choix de tags axiaux (univers/situation/voix) plutôt que des jeux distincts par combinaison.
+2. **Période transition** — les anciens documents (`README.md`, `architecture.md`, etc.) restent-ils actifs en lecture publique pendant la transition, ou sont-ils marqués obsolètes immédiatement ?
+3. **Cible MVP** — bien que le périmètre vise toutes les features, sur laquelle valider le pipeline end-to-end en premier ? (proposition par défaut : `suggestion de dialogue` #77, niveau fragments + entités, le plus simple.)
+4. **Seuil d'activation du filtre** — un best-of-N nécessite N candidats minimum ; pour les features où la base de tables est encore petite, fallback à top-1 du recombinateur ?

--- a/aidd_docs/memory/architecture-tables-ml.md
+++ b/aidd_docs/memory/architecture-tables-ml.md
@@ -77,8 +77,10 @@ flowchart TD
 ### Étage 3 — Recombinateur
 
 - **Rôle** : tirer K échantillons par étage de granularité (beat → template → slots remplis depuis entités) et les assembler en N candidats de sortie textuelle.
-- **Modèle** : règles d'assemblage déterministes pour les cas simples, petit modèle séquentiel optionnel pour le sequencing complexe.
+- **Modèle** : aucun. Règles d'assemblage déterministes + remplissage de slots typés. Les variantes d'accord (genre, nombre, temps, ponctuation) sont **pré-stockées comme rows distinctes** dans les tables, sélectionnées par contexte aux étages 1/2. Pas de génération séquentielle.
 - **Sortie** : N candidats (typiquement N = 5 à 10).
+
+Cette contrainte stricte sur l'étage 3 est ce qui rend tenable la promesse « zéro génération autoregressive » de `philosophy.md` §7. Si un cas d'usage requiert un assemblage que les règles ne couvrent pas, la résolution est d'**ajouter des rows à la table**, pas d'introduire un modèle génératif.
 
 ### Étage 4 — Filtreur
 
@@ -95,6 +97,8 @@ flowchart TD
 | Suggestion description (#79)         | templates + entités (lieux/ambiances)        | tous                                                          |
 | Suggestion pensée intérieure (#80)   | beats + templates + entités                  | tous                                                          |
 | Export prompt vidéo (#89)            | templates visuels + entités                  | sélecteur + pondérateur + recombinateur (canevas fixe, pas de filtre best-of-N) |
+
+Les features d'analyse (#81–#84) ont leur propre mapping dans la section suivante. Les neuf features de `use-cases.md` sont couvertes au total par les deux tables (cinq ici, quatre ci-dessous).
 
 ## Pipeline d'analyse — projection inversée
 
@@ -126,6 +130,24 @@ flowchart TD
 | Résumé de session (#83)          | templates de résumé tagués genre/situation              | extraction de beats par projection + remplissage du template |
 | Suggestions liens fédérés (#84)  | embeddings des personnages publics de l'instance        | similarité d'embeddings + seuil                            |
 
+Le pipeline d'analyse est volontairement spécifié à un niveau d'abstraction supérieur à celui du pipeline de génération. Le matcher (classifieur multi-label ou similarité avec seuil), l'agrégateur (somme pondérée, vote majoritaire, fonctions par feature) et le format des rapports restent à figer dans un document dédié (`analysis-pipeline.md` à venir). Le MVP cible le pipeline de génération en premier.
+
+## Carte de couverture contextuelle
+
+Artefact structurel maintenu par le service Muses : tableau indexé par `(univers × situation × voix)` qui agrège, par cellule contextuelle :
+
+- nombre de rows par niveau (entités, templates, beats, fragments),
+- nombre d'auteurs distincts trusted ayant contribué dans cette cellule,
+- date de la dernière contribution.
+
+Usage :
+
+- **Diagnostic** — repérer les zones creuses et prioriser le mining bootstrap ou la sollicitation de contributions.
+- **Fallback hiérarchique** — quand la cellule cible est sous-peuplée, l'étage 1 (sélecteur) peut tomber gracieusement sur une cellule voisine (un axe relâché à la fois : voix → situation → univers).
+- **Décision MVP** — sélection des cellules à servir en priorité v1.
+
+La carte est référencée dans `learning-and-trust.md` §6 comme garde-fou anti-cold-start.
+
 ## Provenance des tables
 
 Trois voies d'alimentation à combiner :
@@ -154,14 +176,18 @@ Trois voies d'alimentation à combiner :
 - Choix précis des modèles ML (à figer en POC).
 - Schéma détaillé des tables (champ par champ).
 - Pipeline de fabrication des tables depuis le corpus existant.
-- Refonte de la grille tarifaire Muses (l'inférence quasi gratuite invalide la grille actuelle de `use-cases.md` §1.2).
+- Refonte de la grille tarifaire de `use-cases.md` §1.2 (l'inférence quasi gratuite invalide la grille actuelle). Cf. `philosophy.md` § Conventions sur le renommage de la monnaie en « unité d'usage ».
 - Réécriture de la doc périmée (`README.md`, `architecture.md`, `project_brief.md`, `codebase_map.md`).
+- **Infrastructure du service** — résilience, haute disponibilité, plan de continuité. Le service Muses étant unique (cf. `philosophy.md` §2), c'est un single point of failure pour les features IA de toutes les instances. À traiter dans un `infrastructure.md` dédié (HA actif/passif ? réplication géo ? cache local par instance ?).
+- **Authentification des instances** — chaque requête entrante doit être signée par une instance authentifiée (signature HTTP ActivityPub, déjà prévue par `project_brief.md`). Spec à formaliser dans le doc infrastructure.
+- **Mode dégradé** — quand Muses est indisponible côté instance Suddenly : comportement attendu spécifié dans `use-cases.md` #4.3 (boutons IA masqués ou messagés, pas de débit). Implémentation côté instance, pas côté Muses.
 
 Chacun de ces points fera l'objet d'un document dédié.
 
 ## Questions ouvertes à acter
 
-1. **Tagging vs jeux de tables séparés** — confirmer le choix de tags axiaux (univers/situation/voix) plutôt que des jeux distincts par combinaison.
-2. **Période transition** — les anciens documents (`README.md`, `architecture.md`, etc.) restent-ils actifs en lecture publique pendant la transition, ou sont-ils marqués obsolètes immédiatement ?
-3. **Cible MVP** — bien que le périmètre vise toutes les features, sur laquelle valider le pipeline end-to-end en premier ? (proposition par défaut : `suggestion de dialogue` #77, niveau fragments + entités, le plus simple.)
-4. **Seuil d'activation du filtre** — un best-of-N nécessite N candidats minimum ; pour les features où la base de tables est encore petite, fallback à top-1 du recombinateur ?
+1. **Période transition** — les anciens documents (`README.md`, `architecture.md`, etc.) restent-ils actifs en lecture publique pendant la transition, ou sont-ils marqués obsolètes immédiatement ?
+2. **Cible MVP** — bien que le périmètre vise toutes les features, sur laquelle valider le pipeline end-to-end en premier ? (proposition par défaut : `suggestion de dialogue` #77, niveau fragments + entités, le plus simple.)
+3. **Seuil d'activation du filtre** — un best-of-N nécessite N candidats minimum ; pour les features où la base de tables est encore petite, fallback à top-1 du recombinateur ?
+
+Choix précédemment ouverts et désormais actés : tagging axial plutôt que jeux de tables séparés (cf. niveaux de granularité §3) ; axes canoniques `univers / situation / voix` (cf. `philosophy.md` § Conventions).

--- a/aidd_docs/memory/architecture-tables-ml.md
+++ b/aidd_docs/memory/architecture-tables-ml.md
@@ -7,7 +7,7 @@ description: Architecture du pivot vers algorithme de tirage sur tables aléatoi
 
 ## Contexte du pivot
 
-L'approche initiale (LLM fine-tuné + LoRA stacking sur 3 axes — univers, situation, voix) est abandonnée.
+L'approche initiale (LLM fine-tuné + LoRA stacking sur trois axes — `univers`, `situation`, `voix`) est abandonnée. La canonisation actuelle élargit à cinq axes atomiques (cf. `philosophy.md` § Conventions) ; les deux axes ajoutés (`rapport_initial`, `emotion_dominante`) étaient implicites dans l'ancienne approche, ils sont désormais explicites.
 
 **Causes** :
 
@@ -29,7 +29,7 @@ L'approche initiale (LLM fine-tuné + LoRA stacking sur 3 axes — univers, situ
 | Niveau                  | Contenu                                  | Exemples                                                 | Usage                                                |
 | ----------------------- | ---------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
 | **Entités atomiques**   | unités lexicales typées                  | gestes, émotions, lieux, objets, noms, traits            | remplissage de slots, briques pour niveaux supérieurs |
-| **Templates à trous**   | squelettes paramétrés                    | « {char} {geste} en {émotion}, {action_suite} »          | structure de phrase ; slots typés tirent dans les entités |
+| **Templates à trous**   | squelettes paramétrés                    | « {char} {geste} en {emotion}, {action_suite} »          | structure de phrase ; slots typés tirent dans les entités |
 | **Beats narratifs**     | unités de niveau scène                   | « hésitation », « rupture de ton », « révélation »        | décident QUOI dire avant de décider COMMENT          |
 | **Fragments narratifs** | sorties complètes prêtes à l'emploi      | répliques / phrases curées depuis corpus                 | échantillonnés directement si beat + contexte alignés |
 
@@ -44,7 +44,7 @@ Chaque table porte des **tags** sur les cinq axes canoniques (`univers`, `situat
 title: Pipeline de génération table-based
 ---
 flowchart TD
-    Context["Contexte: perso, scène, derniers reports, feature"]
+    Context["Contexte: perso, scène, derniers reports, feature, tags axiaux"]
     Selector["Étage 1 — Sélecteur"]
     Weighter["Étage 2 — Pondérateur"]
     Recombiner["Étage 3 — Recombinateur"]
@@ -84,9 +84,10 @@ Cette contrainte stricte sur l'étage 3 est ce qui rend tenable la promesse « z
 
 ### Étage 4 — Filtreur
 
-- **Rôle** : scoring best-of-N. Évaluer cohérence de chaque candidat avec contexte, style, voix.
+- **Rôle** : scoring best-of-N. Évaluer cohérence de chaque candidat avec le contexte (incluant les cinq tags axiaux) et avec le profil de style du récepteur.
 - **Modèle** : cross-encoder (contexte ↔ candidat) entraîné sur l'historique accept/reject utilisateur.
 - **Sortie** : 1 candidat retenu, top-2 et top-3 gardés pour variations / fallback UI.
+- **Exception** : la feature `export prompt vidéo` (#89) court-circuite cet étage (canevas fixe d'assemblage, pas de best-of-N). Cf. mapping ci-dessous.
 
 ## Mapping feature → niveaux exploités
 
@@ -127,7 +128,7 @@ flowchart TD
 | -------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------- |
 | Cohérence scène (#81)            | types d'incohérence (caractère/ton), beats canoniques   | classification multi-label par fragment de scène           |
 | Cohérence session (#82)          | arcs narratifs canoniques, archétypes personnage        | matching séquentiel de beats + scoring d'arc               |
-| Résumé de session (#83)          | templates de résumé tagués genre/situation              | extraction de beats par projection + remplissage du template |
+| Résumé de session (#83)          | templates de résumé tagués `univers / situation`        | extraction de beats par projection + remplissage du template |
 | Suggestions liens fédérés (#84)  | embeddings des personnages publics de l'instance        | similarité d'embeddings + seuil                            |
 
 Le pipeline d'analyse est volontairement spécifié à un niveau d'abstraction supérieur à celui du pipeline de génération. Le matcher (classifieur multi-label ou similarité avec seuil), l'agrégateur (somme pondérée, vote majoritaire, fonctions par feature) et le format des rapports restent à figer dans un document dédié (`analysis-pipeline.md` à venir). Le MVP cible le pipeline de génération en premier.
@@ -155,7 +156,7 @@ La carte est référencée dans `learning-and-trust.md` §6 comme garde-fou anti
 Trois voies d'alimentation à combiner :
 
 1. **Mining corpus → clustering → tables candidates**
-   - S'appuie sur `pipelines/anonymization/` et `pipelines/crawl_rpv/` (déjà présents).
+   - S'appuie sur les pipelines `pipelines/anonymization/` et `pipelines/crawl_rpv/` (présents dans le repo, hérités de l'ancienne stack LoRA — leur sortie servait au format Axolotl, à réadapter pour produire des rows de tables au format JSONL).
    - Extraction NER, segmentation en beats, dédup + clustering sémantique des fragments.
    - Génère des tables candidates à fort volume mais bruitées.
 2. **Curation manuelle**
@@ -181,7 +182,7 @@ Trois voies d'alimentation à combiner :
 - Refonte de la grille tarifaire de `use-cases.md` §1.2 (l'inférence quasi gratuite invalide la grille actuelle). Cf. `philosophy.md` § Conventions sur le renommage de la monnaie en « unité d'usage ».
 - Réécriture de la doc périmée (`README.md`, `architecture.md`, `project_brief.md`, `codebase_map.md`).
 - **Infrastructure du service** — résilience, haute disponibilité, plan de continuité. Le service Muses étant unique (cf. `philosophy.md` §2), c'est un single point of failure pour les features IA de toutes les instances. À traiter dans un `infrastructure.md` dédié (HA actif/passif ? réplication géo ? cache local par instance ?).
-- **Authentification des instances** — chaque requête entrante doit être signée par une instance authentifiée (signature HTTP ActivityPub, déjà prévue par `project_brief.md`). Spec à formaliser dans le doc infrastructure.
+- **Authentification des instances** — chaque requête entrante doit être signée par une instance authentifiée (signature HTTP ActivityPub). Le principe est hérité de l'ancien `project_brief.md` mais ce dernier est obsolète sur l'archi ; la spec opérationnelle reste à formaliser dans le doc infrastructure à venir.
 - **Mode dégradé** — quand Muses est indisponible côté instance Suddenly : comportement attendu spécifié dans `use-cases.md` #4.3 (boutons IA masqués ou messagés, pas de débit). Implémentation côté instance, pas côté Muses.
 
 Chacun de ces points fera l'objet d'un document dédié.

--- a/aidd_docs/memory/learning-and-trust.md
+++ b/aidd_docs/memory/learning-and-trust.md
@@ -88,12 +88,15 @@ trust[user_id][axis][value] = (alpha, beta, last_update_ts)
 
 ### Update
 
-- **Accept par un tiers** sur une row contribuée par l'auteur dans contexte `(axis, value)` : `α += w_accept`.
-- **Reject_off par un tiers** : `β += w_reject`.
+Symétrique avec la table à 5 signaux de `style-coaching.md` §3 (colonne *Update trust contributeur*) :
+
+- **Accept** par un tiers sur une row contribuée par l'auteur dans contexte `(axis, value)` : `α += w_accept`.
+- **Accept_edited** : `α += w_accept_edited` (atténué — le contenu de l'auteur était proche mais pas suffisant).
+- **Reject_off** : `β += w_reject`.
 - **Reject_challenge_appreciated** : neutre. Le challenge ne pénalise pas son auteur.
 - **Ignore** : `β += w_ignore` (faible).
 
-Les poids `w_*` sont calibrés tels que `w_accept ≈ 1`, `w_reject ≈ 1`, `w_ignore ≈ 0.2`. À ajuster sur données réelles.
+Les poids `w_*` sont calibrés tels que `w_accept ≈ 1`, `w_accept_edited ≈ 0.5`, `w_reject ≈ 1`, `w_ignore ≈ 0.2`. À ajuster sur données réelles.
 
 ### Query
 

--- a/aidd_docs/memory/learning-and-trust.md
+++ b/aidd_docs/memory/learning-and-trust.md
@@ -28,7 +28,7 @@ Muses connaît deux régimes successifs, sans cut-off net entre les deux — dé
 
 ### Transition
 
-Le système ne « bascule » jamais formellement de bootstrap à nominal. La phase nominale grandit en parallèle ; les rows bootstrap restent en place tant qu'elles ne sont pas archivées par le quality gating (§5). À terme, la proportion de rows `source: bootstrap` décroît mécaniquement par dilution.
+Le système ne « bascule » jamais formellement de bootstrap à nominal. La phase nominale grandit en parallèle ; les rows bootstrap restent en place tant qu'elles ne sont pas archivées par le quality gating (§7). À terme, la proportion de rows `source: bootstrap` décroît mécaniquement par dilution.
 
 ## 2. Provenance — schéma de row obligatoire
 
@@ -80,7 +80,7 @@ Les poids des étages 1/2/4 sont snapshottés périodiquement avec horodatage. E
 
 ## 4. Trust contextuel par auteur
 
-Vecteur de Beta reputations indexé par `(axe, valeur)` — cf. message précédent dans la conversation et `philosophy.md` §5.
+Vecteur de Beta reputations indexé par `(axe, valeur)` sur les cinq axes canoniques (`philosophy.md` § Conventions). Principe d'application dans `philosophy.md` §5 (« Décentralisé et responsabilisé »).
 
 ```
 trust[user_id][axis][value] = (alpha, beta, last_update_ts)

--- a/aidd_docs/memory/learning-and-trust.md
+++ b/aidd_docs/memory/learning-and-trust.md
@@ -40,7 +40,7 @@ Chaque row de chaque table porte une provenance complète. Pas d'exception, y co
 | `user_id`          | string    | Acteur ActivityPub (URI), `null` pour `source: bootstrap`           |
 | `instance_id`      | string    | Domaine de l'instance source                                        |
 | `created_at`       | timestamp | Date d'ingestion côté Muses                                         |
-| `source`           | enum      | `bootstrap` \| `contribution_explicit` \| `derived_from_edit` \| `mined` |
+| `source`           | enum      | `bootstrap` \| `contribution_explicit` \| `derived_from_edit` \| `mined` (la valeur `derived_from_edit` est produite par le signal `accept_edited` décrit dans `style-coaching.md` §3) |
 | `signature`        | string    | Signature ActivityPub HTTP de la soumission (sauf `bootstrap` et `mined`) |
 | `quality_score`    | float     | Score courant calculé par le quality gating, mis à jour en continu  |
 | `created_for_axis` | dict      | Axes contextuels de la session d'origine (snapshot)                 |
@@ -179,6 +179,8 @@ quality_score[row] = f(
 )
 ```
 
+La fonction `f()` est délibérément laissée non spécifiée à ce stade — elle sera calibrée empiriquement en POC sur les premières données de production (forme candidate : moyenne pondérée des taux d'accept par contexte, pénalisée par le ratio d'éditions et amortie sur l'âge). Le doc sera figé une fois la calibration tenable.
+
 - **Archivage** des rows sous seuil après période d'observation (pas suppression — archivage permet audit et restauration).
 - **A/B online** : pour des contextes équivalents, deux rows candidates peuvent être servies en alternance pour mesurer leur performance comparée et accélérer la convergence.
 - **Promotion** : une row à très haut quality_score peut voir son embedding renforcé (poids accru à l'étage 2 indépendamment du trust auteur).
@@ -186,7 +188,11 @@ quality_score[row] = f(
 ## 8. Hors périmètre / questions ouvertes
 
 - **Politique de rétention RGPD** : conservation des rows après suppression de compte user. Probable anonymisation (drop du `user_id`, garde du `instance_id`), à confirmer juridiquement.
-- **Migration inter-instance** : un user qui change d'instance Suddenly garde-t-il son trust côté Muses ? Probablement oui via ActivityPub `Move`, mais la signature change — protocole à spécifier.
+- **Continuité d'identité d'un contributeur** — trois cas à traiter ensemble dans un futur protocole d'identité :
+  - migration inter-instance (un user change d'instance Suddenly, l'acteur ActivityPub change) ;
+  - rotation de clé ActivityPub d'un user (signature change, identité logique stable) ;
+  - takeover détecté (cf. §6) puis résolu — restauration partielle du trust ?
+  La piste par défaut est de s'appuyer sur l'activité ActivityPub `Move` *et* sur un mécanisme de claim signé par l'ancienne clé, mais le protocole reste à spécifier.
 - **Visibilité du trust par l'admin d'instance source** : l'admin Muses voit tout ; l'admin d'une instance voit-il les trusts de ses propres users ?
 - **Mécanisme de contestation** : un user qui pense subir un trust injustement bas peut-il déclencher une revue admin ?
 - **Politique de signal pour signal de modération externe** (block d'instance prononcé par une autre instance) — affecte-t-il `instance_weight` ?

--- a/aidd_docs/memory/learning-and-trust.md
+++ b/aidd_docs/memory/learning-and-trust.md
@@ -1,0 +1,193 @@
+---
+name: learning-and-trust
+description: Régime de données bootstrap puis continu, online learning des étages ML, trust contextuel et résilience décentralisée
+---
+
+# Apprentissage continu et trust
+
+> Ancre dans `philosophy.md` §2 (« Une couche, pas une instance »), §3 (« Continu, pas batch ») et §5 (« Décentralisé et responsabilisé »). Spécifie comment Muses ingère des données et apprend en continu sans re-training batch, et comment il filtre les contributions ouvertes du Fediverse sans modération réactive 24/7.
+
+Le pipeline 4-étages et les niveaux de tables auxquels ce document fait référence sont définis dans `architecture-tables-ml.md`. Le profil de style auteur (orthogonal au trust) est spécifié dans `style-coaching.md`.
+
+## 1. Régime de données : bootstrap → continu
+
+Muses connaît deux régimes successifs, sans cut-off net entre les deux — déplacement progressif du centre de gravité.
+
+### Phase bootstrap (one-shot)
+
+- Sources : corpus de visual novels, romans, scrapings de forums RP existants (`pipelines/anonymization`, `pipelines/crawl_rpv`).
+- Pipeline : extraction NER + segmentation en beats + clustering sémantique → tables candidates → curation manuelle → premières tables publiées.
+- Volume cible : suffisant pour ne pas servir de tables vides aux premiers contributeurs. Pas pour atteindre la qualité finale.
+- Toutes les rows issues du bootstrap portent `source: bootstrap` dans leur provenance.
+
+### Régime nominal (continu)
+
+- Sources : contributions des joueurs des instances Suddenly connectées, captées via les signaux UI (cf. `style-coaching.md` §3) et les soumissions explicites opt-in.
+- Pipeline : chaque accept/édition génère un signal qui met à jour les composants ML ; chaque édition originale ou contribution explicite produit un fragment candidat ajouté à la table appropriée.
+- Aucun re-training batch. Aucune version de modèle.
+
+### Transition
+
+Le système ne « bascule » jamais formellement de bootstrap à nominal. La phase nominale grandit en parallèle ; les rows bootstrap restent en place tant qu'elles ne sont pas archivées par le quality gating (§5). À terme, la proportion de rows `source: bootstrap` décroît mécaniquement par dilution.
+
+## 2. Provenance — schéma de row obligatoire
+
+Chaque row de chaque table porte une provenance complète. Pas d'exception, y compris pour les rows bootstrap (provenance synthétique).
+
+| Champ              | Type      | Description                                                         |
+| ------------------ | --------- | ------------------------------------------------------------------- |
+| `id`               | UUID      | Identifiant interne Muses                                           |
+| `user_id`          | string    | Acteur ActivityPub (URI), `null` pour `source: bootstrap`           |
+| `instance_id`      | string    | Domaine de l'instance source                                        |
+| `created_at`       | timestamp | Date d'ingestion côté Muses                                         |
+| `source`           | enum      | `bootstrap` \| `contribution_explicit` \| `derived_from_edit` \| `mined` |
+| `signature`        | string    | Signature ActivityPub HTTP de la soumission (sauf `bootstrap` et `mined`) |
+| `quality_score`    | float     | Score courant calculé par le quality gating, mis à jour en continu  |
+| `created_for_axis` | dict      | Axes contextuels de la session d'origine (snapshot)                 |
+
+La provenance permet : attribution, pondération par trust user et trust instance, archivage ciblé, audit.
+
+## 3. Online learning des étages ML
+
+Aucun entraînement batch. Trois étages sur quatre apprennent en continu.
+
+### Étage 1 — Sélecteur
+
+- **Forme** : classifieur multi-label logistique sur embedding du contexte → P(table_t pertinente | ctx).
+- **Update** : SGD online à chaque session terminée. Signal positif sur les tables d'où viennent les rows acceptées ; signal négatif sur les tables des rows ignorées.
+- **Snapshots** : poids sérialisés toutes les N heures pour rollback en cas de drift constaté.
+
+### Étage 2 — Pondérateur
+
+- **Forme** : similarité contexte ↔ row dans l'espace d'embedding partagé, soft-maxée sur les rows de chaque table sélectionnée.
+- **Update** : pairwise learning. Sur un couple `(accept row r, reject_off row r')` dans le même contexte, gradient hinge : pousse `sim(ctx, r) > sim(ctx, r')`.
+- L'étage 2 est aussi le point d'application de la pondération trust et de la modulation confort/challenge (cf. `style-coaching.md` §2). Ces multiplicateurs s'appliquent **après** la distribution apprise.
+
+### Étage 3 — Recombinateur
+
+- **N'apprend pas.** Règles d'assemblage déterministes + remplissage de slots typés.
+- Les variantes d'accord (genre, nombre, temps) sont pré-stockées dans les rows, pas générées.
+
+### Étage 4 — Filtreur
+
+- **Forme** : scoreur best-of-N (cross-encoder léger ou somme pondérée de features) sur `(contexte, candidat)`.
+- **Update** : preference learning style DPO-lite. Sur un signal `(winner candidat retenu, loser candidat dominé)`, gradient pousse `s(winner) - s(loser)` vers le positif.
+- **Désambiguïsation** : les signaux `reject_challenge_appreciated` (cf. `style-coaching.md` §3) **n'alimentent pas** l'update du filtreur — sinon le mode challenge collapse.
+
+### Snapshots et rollback
+
+Les poids des étages 1/2/4 sont snapshottés périodiquement avec horodatage. En cas de dérive constatée (drift, raid massif détecté a posteriori, bug d'update), rollback possible à un snapshot daté. Les rows ajoutées entre-temps **ne sont pas** rétro-supprimées, mais leurs signaux d'apprentissage le sont.
+
+## 4. Trust contextuel par auteur
+
+Vecteur de Beta reputations indexé par `(axe, valeur)` — cf. message précédent dans la conversation et `philosophy.md` §5.
+
+```
+trust[user_id][axis][value] = (alpha, beta, last_update_ts)
+```
+
+### Update
+
+- **Accept par un tiers** sur une row contribuée par l'auteur dans contexte `(axis, value)` : `α += w_accept`.
+- **Reject_off par un tiers** : `β += w_reject`.
+- **Reject_challenge_appreciated** : neutre. Le challenge ne pénalise pas son auteur.
+- **Ignore** : `β += w_ignore` (faible).
+
+Les poids `w_*` sont calibrés tels que `w_accept ≈ 1`, `w_reject ≈ 1`, `w_ignore ≈ 0.2`. À ajuster sur données réelles.
+
+### Query
+
+- **Trust moyen** : `α / (α + β)`.
+- **Confiance** : `1 / variance(Beta(α, β))`. Distingue 95% sur 1000 contribs (haute confiance) de 95% sur 5 contribs (faible).
+- En pondération downstream, on utilise un **trust pénalisé par la confiance** — un user à 95% sur 5 contribs vaut `0.5 + (0.95 - 0.5) × confidence_factor`, pas brutalement `0.95`.
+
+### Décroissance temporelle
+
+Demi-vie de **~6 mois** sur `α` et `β` (plus longue que la demi-vie ~3 mois du profil de style — un auteur peut évoluer en style sans devenir moins fiable). Décroissance appliquée au calcul (pas mutation in-place) pour permettre l'audit.
+
+### Cold start
+
+Prior `Beta(1, 1)` : trust = 0.5, confiance basse. Multiplié par la réputation d'instance (§5), ça donne un poids initial raisonnable.
+
+## 5. Réputation d'instance
+
+```
+instance_weight[instance_id] = (
+    base_multiplier: float ∈ [0.3, 1.2],
+    reviewed_at: timestamp,
+    source: 'auto' | 'admin'
+)
+```
+
+### Calcul automatique
+
+Agrégat sur les contribs de l'instance ces N derniers mois :
+- taux de `reject_off` moyen,
+- taux d'archivage par quality gating,
+- volume / régularité,
+- signalements inter-instances.
+
+Le multiplicateur est borné `[0.3, 1.2]` — une mauvaise instance ne fait pas tomber ses users à 0, et une bonne instance ne crée pas d'oligarchie.
+
+### Override admin
+
+Admin Muses peut figer un `base_multiplier` (ex: instance fraîchement créée mais opérée par une communauté connue), avec `source: 'admin'`. La revue auto reprend ensuite si l'override expire.
+
+### Application
+
+Au moment de la pondération à l'étage 2, le multiplicateur d'instance porte sur le **trust effectif du user au moment de la contribution** :
+
+```
+weight_eff(row) =
+      prob_apprise(row | ctx)
+    × Π_axis  trust_penalized(row.user, axis, ctx[axis])
+    × instance_weight[row.instance].base_multiplier
+    × time_decay(row.created_at)
+    × confort_challenge_modulation(row, user_courant)
+```
+
+## 6. Garde-fous décentralisés
+
+### Anti-sleeper
+
+Borner le **gain max** de `α` par fenêtre temporelle (proposé : `+10` par jour par `(axe, valeur)`). Un user qui ferait soudain 500 contribs acceptables en 24h ne saute pas à un trust ultra-confiant. La construction de réputation reste lente — c'est voulu.
+
+### Anti-takeover
+
+Détection d'**anomalie comportementale** sur les contribs : embedding moyen des K dernières contribs vs profil historique du user. Déviation supérieure à un seuil → suspension temporaire du bénéfice du trust + alerte admin Muses. L'auteur peut écrire normalement, ses contribs juste ne portent plus son ancien trust.
+
+### Anti-sybil
+
+- Seuil minimum d'activité (M contribs sur P semaines) avant que le trust commence à compter au-delà du prior.
+- Couplage à la signature ActivityPub — un nouveau user dans une instance existante hérite partiellement de la réputation d'instance, mais doit construire son propre trust.
+- Détection statistique de clusters de comptes corrélés (signature comportementale) — sans la résoudre côté Muses, mais en signalant aux admins de l'instance source.
+
+### Anti-cold-start sur zones rares
+
+Maintenir une **carte de couverture** sur l'espace `(univers × situation × voix)`. Les cellules sous-peuplées (peu de rows, peu d'auteurs trusted) sont marquées et priorisées pour le mining bootstrap futur. L'étage 1 peut tomber gracieusement sur des tables voisines (fallback hiérarchique sur axes).
+
+## 7. Quality gating
+
+Score qualité maintenu par row, indépendant du trust de l'auteur.
+
+```
+quality_score[row] = f(
+    accepts_in_similar_contexts,
+    rejects_in_similar_contexts,
+    edits_count,
+    age,
+)
+```
+
+- **Archivage** des rows sous seuil après période d'observation (pas suppression — archivage permet audit et restauration).
+- **A/B online** : pour des contextes équivalents, deux rows candidates peuvent être servies en alternance pour mesurer leur performance comparée et accélérer la convergence.
+- **Promotion** : une row à très haut quality_score peut voir son embedding renforcé (poids accru à l'étage 2 indépendamment du trust auteur).
+
+## 8. Hors périmètre / questions ouvertes
+
+- **Politique de rétention RGPD** : conservation des rows après suppression de compte user. Probable anonymisation (drop du `user_id`, garde du `instance_id`), à confirmer juridiquement.
+- **Migration inter-instance** : un user qui change d'instance Suddenly garde-t-il son trust côté Muses ? Probablement oui via ActivityPub `Move`, mais la signature change — protocole à spécifier.
+- **Visibilité du trust par l'admin d'instance source** : l'admin Muses voit tout ; l'admin d'une instance voit-il les trusts de ses propres users ?
+- **Mécanisme de contestation** : un user qui pense subir un trust injustement bas peut-il déclencher une revue admin ?
+- **Politique de signal pour signal de modération externe** (block d'instance prononcé par une autre instance) — affecte-t-il `instance_weight` ?
+- **Calibration fine** des constantes (demi-vie 6 mois, bornes multiplicateurs, poids `w_*`, seuils d'archivage, taille des fenêtres anti-sleeper) — à itérer sur données réelles, pas à figer maintenant.

--- a/aidd_docs/memory/learning-and-trust.md
+++ b/aidd_docs/memory/learning-and-trust.md
@@ -167,7 +167,7 @@ Détection d'**anomalie comportementale** sur les contribs : embedding moyen des
 
 ### Anti-cold-start sur zones rares
 
-Maintenir une **carte de couverture** sur l'espace `(univers × situation × voix)`. Les cellules sous-peuplées (peu de rows, peu d'auteurs trusted) sont marquées et priorisées pour le mining bootstrap futur. L'étage 1 peut tomber gracieusement sur des tables voisines (fallback hiérarchique sur axes).
+Maintenir une **carte de couverture** sur l'hypercube canonique `(univers × situation × rapport_initial × voix × emotion_dominante)` — définie dans `architecture-tables-ml.md` § Carte de couverture contextuelle. Les cellules sous-peuplées sont marquées et priorisées pour le mining bootstrap futur. L'étage 1 peut tomber gracieusement sur des tables voisines (fallback hiérarchique sur axes, ordre `emotion_dominante → voix → rapport_initial → situation → univers`).
 
 ## 7. Quality gating
 

--- a/aidd_docs/memory/philosophy.md
+++ b/aidd_docs/memory/philosophy.md
@@ -9,6 +9,12 @@ description: Identité et principes directeurs du projet Muses — ce qu'il est,
 
 Ce document fixe l'identité du projet. Les choix d'architecture, de modèle de données et d'implémentation découlent de ces principes — non l'inverse. En cas de conflit entre une décision technique et un principe ici, le principe l'emporte (ou il faut explicitement actualiser ce document).
 
+## Conventions
+
+- **« Muses »** dans tous les documents de ce dossier désigne le **projet et le service**. La grille monétaire qui porte le même nom dans `use-cases.md` §1.2 est un artefact de l'ancienne architecture LoRA, et doit être renommée lors de la réécriture de `use-cases.md`. Provisoirement, cette monnaie est référencée comme **« unité d'usage »** dans les futurs documents tarifaires.
+- **Axes contextuels canoniques** : `univers`, `situation`, `voix` (3 axes). Toute référence à un autre set d'axes (`genre` dans `use-cases.md`, par exemple) est obsolète. Définition détaillée des valeurs : à formaliser dans un futur `axes-and-tags.md`.
+- **« Trust »** et non « réputation » comme terme principal pour le crédit accordé à un contributeur. Le terme technique `Beta reputation` (Jøsang) reste utilisé quand il désigne la primitive statistique.
+
 ## 1. Une muse, pas un serviteur
 
 L'objectif n'est pas de remplacer l'auteur, ni d'écrire à sa place. Muses **interroge** le style de l'auteur et le **pousse hors de ses habitudes** quand il le souhaite.
@@ -80,8 +86,7 @@ Ce choix n'est pas une contrainte budgétaire : c'est une condition de **viabili
 
 - Pas un LLM, pas un chatbot.
 - Pas un substitut à l'auteur : il propose, l'auteur arbitre.
-- Pas une instance Suddenly de plus.
-- Pas un assistant généraliste : son terrain est la rédaction de fiction narrative et dialoguée (les features de `use-cases.md`). Pas la productivité bureautique, pas la traduction, pas le code.
+- Pas un assistant généraliste : son terrain est la rédaction de fiction narrative et dialoguée (les features de `use-cases.md`). Pas la productivité bureautique, pas la traduction entre langues humaines, pas le code. La transformation d'une scène vers un prompt vidéo (feature #89) reste sur le terrain narratif.
 - Pas un système versionné. Pas de « v2 du modèle ». C'est un service continu.
 - Pas de génération autoregressive. Le coût d'inférence est borné par un nombre fixe de forward passes (embeddings, classifieurs, scoreurs), indépendant de la longueur de la sortie.
 

--- a/aidd_docs/memory/philosophy.md
+++ b/aidd_docs/memory/philosophy.md
@@ -99,6 +99,8 @@ Ce choix n'est pas une contrainte budgétaire : c'est une condition de **viabili
 
 ## Documents techniques liés
 
-- `architecture-tables-ml.md` — pipeline 4-étages tables + ML, et asymétrie génération / analyse (existe).
-- `learning-and-trust.md` — bootstrap → continu, online learning des étages ML, trust contextuel, réputation d'instance (à écrire).
-- `style-coaching.md` — profil de style auteur, modes confort / challenge, meta-suggestions sur le style (à écrire).
+- `architecture-tables-ml.md` — pipeline 4-étages tables + ML, et asymétrie génération / analyse.
+- `learning-and-trust.md` — bootstrap → continu, online learning des étages ML, trust contextuel, réputation d'instance.
+- `style-coaching.md` — profil de style auteur, modes confort / challenge, méta-suggestions sur le style.
+
+Documents techniques projetés (non encore écrits) : `axes-and-tags.md` (taxonomie détaillée des valeurs sur les cinq axes), `analysis-pipeline.md` (spec opérationnelle de la projection inversée), `infrastructure.md` (HA, auth, mode dégradé), refonte tarifaire.

--- a/aidd_docs/memory/philosophy.md
+++ b/aidd_docs/memory/philosophy.md
@@ -1,0 +1,92 @@
+---
+name: philosophy
+description: Identité et principes directeurs du projet Muses — ce qu'il est, ce qu'il n'est pas, et pourquoi
+---
+
+# Philosophie — Muses
+
+> Muses est une couche d'assistance créative pour le Fediverse Suddenly. Une muse au sens classique : elle provoque, elle ne sert pas.
+
+Ce document fixe l'identité du projet. Les choix d'architecture, de modèle de données et d'implémentation découlent de ces principes — non l'inverse. En cas de conflit entre une décision technique et un principe ici, le principe l'emporte (ou il faut explicitement actualiser ce document).
+
+## 1. Une muse, pas un serviteur
+
+L'objectif n'est pas de remplacer l'auteur, ni d'écrire à sa place. Muses **interroge** le style de l'auteur et le **pousse hors de ses habitudes** quand il le souhaite.
+
+Deux modes coexistent :
+
+- **Confort** — les suggestions s'alignent au style établi de l'auteur, pour fluidifier la rédaction.
+- **Challenge** — les suggestions s'écartent volontairement des habitudes, pour ouvrir des chemins inexplorés.
+
+Ce mode dual est constitutif du produit, pas une option. Sans le mode challenge, Muses deviendrait un amplificateur d'habitudes et appauvrirait progressivement la production des auteurs.
+
+## 2. Une couche, pas une instance
+
+Muses n'est pas une instance Suddenly de plus. C'est un **service unique, mutualisé** entre toutes les instances Suddenly du Fediverse, qui s'y connectent via ActivityPub.
+
+Conséquences :
+
+- Données et apprentissages **partagés** entre instances : une bonne contribution d'une instance bénéficie aux auteurs d'une autre.
+- Modération **commune** : un système de trust contextuel arbitre la qualité des contributions, modulé par la réputation de chaque instance source.
+- Auteurialité **individuelle** : chaque contribution reste attribuée à son auteur (signature ActivityPub).
+
+## 3. Continu, pas batch
+
+Muses ne se ré-entraîne pas. Il n'y a pas de « version 2.0 » du modèle.
+
+- Les tables s'enrichissent **ligne par ligne** au fil des contributions.
+- Les composants ML se mettent à jour **incrémentalement** sur chaque signal (accept / reject / édition).
+- Le corpus VN / romans / forums sert uniquement à **amorcer la pompe** au démarrage. Une fois le régime nominal atteint, les contributions joueurs deviennent la source dominante.
+
+Cette propriété disqualifie les LoRA et le fine-tuning batché, et motive le choix d'une architecture tables + petits modèles ML.
+
+## 4. Boucle bidirectionnelle
+
+Muses apprend des contributeurs. Mais il fait aussi **apprendre** les contributeurs.
+
+- Le système peut surfacer des observations sur le style de chaque auteur (« tu surutilises tel beat », « tu n'as jamais exploré tel champ lexical »).
+- Le mode challenge confronte volontairement l'auteur à des choix qu'il n'aurait pas faits seul.
+- L'objectif co-construit : faire évoluer collectivement la qualité du corpus *et* la qualité d'écriture des contributeurs.
+
+## 5. Décentralisé et responsabilisé
+
+Les contributions sont ouvertes à tous les joueurs des instances Suddenly connectées. Mais cette ouverture est **pondérée**, pas naïve.
+
+- **Trust contextuel par auteur** sur chaque axe (univers, situation, voix) — un auteur peut être fiable sur certains contextes et neutre ailleurs.
+- **Réputation d'instance** comme multiplicateur global — une instance bien modérée renforce ses auteurs, une instance lax dilue les leurs.
+- **Visibilité réservée aux administrateurs** — les auteurs ne voient pas leur trust score, pour éviter le gaming.
+
+L'objectif : faire en sorte qu'un raid de contributions toxiques soit dilué par la masse des contributions de qualité, sans nécessiter une modération réactive 24/7.
+
+## 6. Lisible et traçable
+
+Aucune génération boîte-noire. Chaque sortie de Muses est **traçable** jusqu'aux lignes de table tirées et aux scores qui les ont sélectionnées.
+
+- Les tables sont curées explicitement, en JSONL versionné en git.
+- Les choix des étages ML sont inspectables (tirage dans table X, ligne Y, scoré Z par contexte W).
+- Un auteur peut comprendre **pourquoi** Muses lui a proposé telle suggestion — et la contester.
+
+Cette propriété distingue Muses des LLM commerciaux opaques. Elle découle du choix tables + ML léger, pas d'une couche d'explicabilité ajoutée a posteriori.
+
+## 7. Frugal
+
+Pas de GPU, pas d'inférence LLM en production. Tous les composants ML tournent sur CPU : classifieurs légers, embeddings, rerankers.
+
+Ce choix n'est pas une contrainte budgétaire : c'est une condition de **viabilité économique** pour un service partagé et gratuit pour les instances Suddenly. Et une condition d'**indépendance technologique** vis-à-vis des providers d'inférence commerciaux.
+
+## 8. Ce que Muses n'est pas
+
+- Pas un LLM, pas un chatbot.
+- Pas un substitut à l'auteur : il propose, l'auteur arbitre.
+- Pas une instance Suddenly de plus.
+- Pas un assistant généraliste : son terrain est la rédaction de fiction narrative et dialoguée (les features de `use-cases.md`). Pas la productivité bureautique, pas la traduction, pas le code.
+- Pas un système versionné. Pas de « v2 du modèle ». C'est un service continu.
+- Pas une inférence payante par token. Le coût est dans l'orchestration et la curation, pas dans la génération.
+
+---
+
+## Documents techniques liés
+
+- `architecture-tables-ml.md` — pipeline 4-étages tables + ML, et asymétrie génération / analyse (existe).
+- `learning-and-trust.md` — bootstrap → continu, online learning des étages ML, trust contextuel, réputation d'instance (à écrire).
+- `style-coaching.md` — profil de style auteur, modes confort / challenge, meta-suggestions sur le style (à écrire).

--- a/aidd_docs/memory/philosophy.md
+++ b/aidd_docs/memory/philosophy.md
@@ -72,6 +72,8 @@ Cette propriété distingue Muses des LLM commerciaux opaques. Elle découle du 
 
 Pas de GPU, pas d'inférence LLM en production. Tous les composants ML tournent sur CPU : classifieurs légers, embeddings, rerankers.
 
+**Aucun composant ne génère de texte token par token.** Les étages ML produisent des scores, des classifications, des vecteurs. Le texte sortant est toujours une recomposition de lignes curées des tables (sélection, remplissage de slots typés, assemblage par règles d'accord). Les modèles d'embedding tokenisent leur entrée en interne, mais leur sortie est un vecteur de dimension fixe — coût par texte borné, pas linéaire à la longueur de sortie.
+
 Ce choix n'est pas une contrainte budgétaire : c'est une condition de **viabilité économique** pour un service partagé et gratuit pour les instances Suddenly. Et une condition d'**indépendance technologique** vis-à-vis des providers d'inférence commerciaux.
 
 ## 8. Ce que Muses n'est pas
@@ -81,7 +83,7 @@ Ce choix n'est pas une contrainte budgétaire : c'est une condition de **viabili
 - Pas une instance Suddenly de plus.
 - Pas un assistant généraliste : son terrain est la rédaction de fiction narrative et dialoguée (les features de `use-cases.md`). Pas la productivité bureautique, pas la traduction, pas le code.
 - Pas un système versionné. Pas de « v2 du modèle ». C'est un service continu.
-- Pas une inférence payante par token. Le coût est dans l'orchestration et la curation, pas dans la génération.
+- Pas de génération autoregressive. Le coût d'inférence est borné par un nombre fixe de forward passes (embeddings, classifieurs, scoreurs), indépendant de la longueur de la sortie.
 
 ---
 

--- a/aidd_docs/memory/philosophy.md
+++ b/aidd_docs/memory/philosophy.md
@@ -12,7 +12,12 @@ Ce document fixe l'identité du projet. Les choix d'architecture, de modèle de 
 ## Conventions
 
 - **« Muses »** dans tous les documents de ce dossier désigne le **projet et le service**. La grille monétaire qui porte le même nom dans `use-cases.md` §1.2 est un artefact de l'ancienne architecture LoRA, et doit être renommée lors de la réécriture de `use-cases.md`. Provisoirement, cette monnaie est référencée comme **« unité d'usage »** dans les futurs documents tarifaires.
-- **Axes contextuels canoniques** : `univers`, `situation`, `voix` (3 axes). Toute référence à un autre set d'axes (`genre` dans `use-cases.md`, par exemple) est obsolète. Définition détaillée des valeurs : à formaliser dans un futur `axes-and-tags.md`.
+- **Axes contextuels canoniques** : cinq axes atomiques indépendants. Toute référence à un autre set d'axes (`genre` dans `use-cases.md`, le triplet `univers / situation / voix` des anciens commits) est obsolète. Définition détaillée des valeurs : à formaliser dans un futur `axes-and-tags.md`.
+  1. `univers` — genre / lore (`medieval-fantastique`, `cyberpunk`, `steampunk`, `horreur-gothique`…).
+  2. `situation` — type de scène (`combat`, `romance`, `intrigue`, `politique`, `quotidien`…).
+  3. `rapport_initial` — relation entre protagonistes au début de la scène (`hostile`, `neutre`, `amical`). Conditionne radicalement le ton — un combat amical (sparring) et un combat hostile n'ont rien à voir.
+  4. `voix` — style narratif du MJ (`solennel`, `narquois`, `theatral`, `neutre`, `lyrique`…).
+  5. `emotion_dominante` — émotion principale de la scène, taxonomie **Ekman 6** : `colere`, `degout`, `peur`, `joie`, `tristesse`, `surprise`. Conditionne le lexique activé.
 - **« Trust »** et non « réputation » comme terme principal pour le crédit accordé à un contributeur. Le terme technique `Beta reputation` (Jøsang) reste utilisé quand il désigne la primitive statistique.
 
 ## 1. Une muse, pas un serviteur
@@ -58,7 +63,7 @@ Muses apprend des contributeurs. Mais il fait aussi **apprendre** les contribute
 
 Les contributions sont ouvertes à tous les joueurs des instances Suddenly connectées. Mais cette ouverture est **pondérée**, pas naïve.
 
-- **Trust contextuel par auteur** sur chaque axe (univers, situation, voix) — un auteur peut être fiable sur certains contextes et neutre ailleurs.
+- **Trust contextuel par auteur** sur chaque axe canonique (cf. § Conventions) — un auteur peut être fiable sur certains contextes et neutre ailleurs.
 - **Réputation d'instance** comme multiplicateur global — une instance bien modérée renforce ses auteurs, une instance lax dilue les leurs.
 - **Visibilité réservée aux administrateurs** — les auteurs ne voient pas leur trust score, pour éviter le gaming.
 

--- a/aidd_docs/memory/style-coaching.md
+++ b/aidd_docs/memory/style-coaching.md
@@ -1,0 +1,116 @@
+---
+name: style-coaching
+description: Profil de style auteur, modes confort et challenge, méta-suggestions sur le style
+---
+
+# Style coaching — Profil auteur et modes confort / challenge
+
+> Ancre dans `philosophy.md` §1 (« Une muse, pas un serviteur ») et §4 (« Boucle bidirectionnelle »). Spécifie le mécanisme par lequel Muses challenge un auteur sans dériver vers l'amplificateur d'habitudes que la seule boucle accept/reject produirait.
+
+Le pipeline 4-étages auquel ce document fait référence est défini dans `architecture-tables-ml.md`.
+
+## 1. Profil de style auteur
+
+Le profil de style est distinct du trust, sur un axe orthogonal.
+
+|                    | Trust                                              | Profil de style                                                |
+| ------------------ | -------------------------------------------------- | -------------------------------------------------------------- |
+| Question répondue  | Cet auteur est-il fiable comme contributeur ?      | Cet auteur écrit dans quel style ?                             |
+| Sources            | Accept/reject **des autres** sur ses contribs      | Accept/édition **par lui** des suggestions reçues + contenu rédigé |
+| Forme              | Vecteur `(α, β)` par `(axe, valeur)`               | Histogrammes avec décroissance temporelle, à 4 niveaux         |
+| Usage downstream   | Pondère ses contribs entrantes (étage 2)           | Personnalise les sorties qu'on lui propose (étages 2/3/4)      |
+
+### Quatre niveaux d'observation
+
+Parallèles aux quatre niveaux de tables :
+
+- **Fréquence par row** — quelles lignes spécifiques l'auteur a acceptées ou réutilisées (histogramme sparse).
+- **Fréquence par template** — quels squelettes il utilise spontanément.
+- **Fréquence par beat** — quels beats narratifs il sollicite (`hésitation` dominante ? `rebondissement` rare ?).
+- **Profil lexical** — vocabulaire dominant, longueur moyenne par feature, ratio dialogue / description / action / pensée.
+
+Chaque dimension porte une **décroissance temporelle** (demi-vie ~3 mois proposée) — le profil reflète l'auteur courant, pas son passé fossilisé.
+
+### Granularité contextuelle
+
+Le profil est sous-indexé par `(axe, valeur)` au même niveau que le trust. Un auteur peut avoir un profil dense en `combat`+`medieval-fantastique` et quasi-vide en `romance`+`cyberpunk` — les deux situations sont traitées différemment par le système.
+
+## 2. Deux modes opératoires
+
+Le mode actif sur une requête est déterminé par :
+
+- toggle UI explicite (« mode challenge » sur la session ou par requête) ;
+- détection automatique (l'auteur réutilise N fois le même beat consécutivement → propose un challenge) ;
+- feature dédiée (`propose-moi hors de ma zone`).
+
+### Mode confort
+
+Objectif : fluidifier la rédaction sans rompre le style.
+
+| Étage             | Comportement confort                                                |
+| ----------------- | ------------------------------------------------------------------- |
+| 1. Sélecteur      | Inchangé — choix des tables par contexte                            |
+| 2. Pondérateur    | **Bonus** sur les rows proches du profil (similarité haute → poids ↑) |
+| 3. Recombinateur  | Favorise combos beats/templates **présents** dans l'historique récent |
+| 4. Filtreur       | Best-of-N par cohérence contexte × proximité au profil              |
+
+### Mode challenge
+
+Objectif : sortir l'auteur de ses ornières, sans le sortir de son univers.
+
+| Étage             | Comportement challenge                                              |
+| ----------------- | ------------------------------------------------------------------- |
+| 1. Sélecteur      | Peut inclure des tables sous-représentées dans son historique       |
+| 2. Pondérateur    | **Malus** sur les rows trop proches du profil (similarité haute → poids ↓) |
+| 3. Recombinateur  | Favorise combos beats/templates **absents** du profil récent        |
+| 4. Filtreur       | Best-of-N avec **Maximum Marginal Relevance** contre le profil      |
+
+Le malus de l'étage 2 reste **borné** : on diversifie l'éventail, on ne le retourne pas. L'auteur doit reconnaître son univers vu sous un angle différent, pas un univers étranger.
+
+## 3. Cinq signaux utilisateur — l'instrumentation critique
+
+Sans désambiguïsation des signaux, le ranker (étage 4) apprend à éviter les challenges (taux d'accept plus bas) et le mode challenge meurt en quelques semaines. C'est mathématique.
+
+L'UI doit donc exposer **cinq** signaux distincts, pas deux :
+
+| Signal                          | Sémantique                                          | Update profil de style                                       | Update ranker étage 4                            |
+| ------------------------------- | --------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------ |
+| `accept`                        | Inséré tel quel                                     | +1 sur row, template, beat, n-grammes                        | +1 sur `(contexte, row)`                         |
+| `accept_edited`                 | Inséré avec édition                                 | +1 sur row brute ; édition capturée comme fragment candidat  | +1 atténué sur la row                            |
+| `reject_off`                    | « Pas pertinent ici »                               | rien                                                         | -1 sur `(contexte, row)`                         |
+| `reject_challenge_appreciated`  | « Bonne idée, pas pour cette scène »                | +1 *exploration* sur le beat/template du candidat            | **neutre** — pas de malus ranker                 |
+| `ignore`                        | Bouton non cliqué après N secondes                  | rien                                                         | -0.2 sur `(contexte, row)`                       |
+
+Le signal `reject_challenge_appreciated` est l'élément crucial. Il décorrèle « la suggestion était pertinente comme exploration » de « je l'ai insérée ». Sans ce signal, le système collapse vers le mode confort en quelques semaines.
+
+Implication UI côté instance Suddenly : sous chaque suggestion, **deux boutons de rejet** — « pas ici » et « pas mal mais pas maintenant ». Pas un seul.
+
+## 4. Méta-suggestions — un nouveau type de sortie
+
+Sortie distincte des suggestions de texte. Format court, surfacé hors flux d'écriture (typiquement dans le profil utilisateur côté instance, ou en surface périodique).
+
+Trois familles :
+
+- **Observation sur l'usage** — « Tu as utilisé le beat *hésitation* dans 70% de tes scènes émotionnelles ce mois-ci. »
+- **Suggestion d'exploration** — « Tu n'as jamais utilisé le champ lexical *organique* dans tes scènes cyberpunk. Tester ? »
+- **Anti-pattern détecté** — « Tes descriptions de combat font en moyenne 40 mots quand tes autres descriptions en font 120. Volontaire ? »
+
+Déclenchement : calcul périodique (batch nocturne) sur le profil de style. **Pas d'interruption dans le flux d'écriture.** Ces méta-suggestions ne consomment aucun Muses — décision à acter dans le document de tarification à venir.
+
+## 5. Garde-fous
+
+- **Calibration du malus challenge** — le multiplicateur étage 2 reste borné dans `[0.3, 1.0]`. Trop bas → l'auteur reçoit du off-style et abandonne le mode.
+- **Cold start** — mode challenge désactivé tant que le profil n'a pas franchi un seuil minimal d'interactions (proposé : ~50 sur l'axe concerné). Sinon on challenge contre du vide.
+- **Réversibilité** — l'auteur peut purger son profil de style à tout moment. RGPD-friendly et utile en cas de changement délibéré de direction stylistique.
+- **Mode forcé hors challenge** — un auteur peut désactiver définitivement le mode challenge. Le produit reste pleinement utile en mode confort pur. Le challenge est une option, pas une imposition.
+- **Visibilité du profil** — l'auteur voit son propre profil de style (au moins les méta-suggestions). C'est l'objet du coaching : sans visibilité, pas de prise de conscience.
+
+Note : la visibilité du **profil de style** par l'auteur diffère de la visibilité du **trust** (admin-only — cf. `learning-and-trust.md` à venir). Le profil parle d'écriture, pas de fiabilité — partager le premier ne crée pas le risque de gaming associé au second.
+
+## 6. Hors périmètre / questions ouvertes
+
+- **Détection automatique du moment opportun** pour proposer un challenge. Heuristique à itérer en POC.
+- **Profil par campagne / par groupe** — un auteur peut écrire différemment dans deux campagnes simultanées. Profil unifié, ou sous-vecteur indexé par `campaign_id` ?
+- **Méta-suggestions sur le rythme** (longueur de scène, alternance dialogue/action/description/pensée) — pertinent ou hors scope ?
+- **Calibration de la décroissance temporelle** du profil (3 mois proposé). À ajuster sur données réelles.
+- **Coaching collectif** — méta-observations sur une campagne entière (« cette campagne a sur-représenté le beat *trahison* ces 2 mois ») — pertinent ou intrusif ?

--- a/aidd_docs/memory/style-coaching.md
+++ b/aidd_docs/memory/style-coaching.md
@@ -71,15 +71,15 @@ Le malus de l'étage 2 reste **borné** : on diversifie l'éventail, on ne le re
 
 Sans désambiguïsation des signaux, le ranker (étage 4) apprend à éviter les challenges (taux d'accept plus bas) et le mode challenge meurt en quelques semaines. C'est mathématique.
 
-L'UI doit donc exposer **cinq** signaux distincts, pas deux :
+L'UI doit donc exposer **cinq** signaux distincts, pas deux. Chaque signal a **trois effets** simultanés et indépendants : sur le profil de style du user qui reçoit la suggestion, sur le ranker étage 4, et sur le trust du user qui a *contribué* la row à l'origine (cf. `learning-and-trust.md` §4). La table ci-dessous donne les trois colonnes ensemble pour éviter toute désynchronisation entre les deux docs.
 
-| Signal                          | Sémantique                                          | Update profil de style                                       | Update ranker étage 4                            |
-| ------------------------------- | --------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------ |
-| `accept`                        | Inséré tel quel                                     | +1 sur row, template, beat, n-grammes                        | +1 sur `(contexte, row)`                         |
-| `accept_edited`                 | Inséré avec édition                                 | +1 sur row brute ; édition capturée comme fragment candidat  | +1 atténué sur la row                            |
-| `reject_off`                    | « Pas pertinent ici »                               | rien                                                         | -1 sur `(contexte, row)`                         |
-| `reject_challenge_appreciated`  | « Bonne idée, pas pour cette scène »                | +1 *exploration* sur le beat/template du candidat            | **neutre** — pas de malus ranker                 |
-| `ignore`                        | Bouton non cliqué après N secondes                  | rien                                                         | -0.2 sur `(contexte, row)`                       |
+| Signal                          | Sémantique                                          | Update profil de style (récepteur)                           | Update ranker étage 4                            | Update trust contributeur (auteur de la row)            |
+| ------------------------------- | --------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------- |
+| `accept`                        | Inséré tel quel                                     | +1 sur row, template, beat, n-grammes                        | +1 sur `(contexte, row)`                         | `α += w_accept` sur `(axis, value)`                     |
+| `accept_edited`                 | Inséré avec édition                                 | +1 sur row brute ; édition capturée comme fragment candidat `source: derived_from_edit` (cf. `learning-and-trust.md` §2) | +1 atténué sur la row                            | `α += w_accept_edited` (atténué)                        |
+| `reject_off`                    | « Pas pertinent ici »                               | rien                                                         | -1 sur `(contexte, row)`                         | `β += w_reject` sur `(axis, value)`                     |
+| `reject_challenge_appreciated`  | « Bonne idée, pas pour cette scène »                | +1 *exploration* sur le beat/template du candidat            | **neutre** — pas de malus ranker                 | **neutre** — un challenge apprécié ne pénalise pas son auteur |
+| `ignore`                        | Bouton non cliqué après N secondes                  | rien                                                         | -0.2 sur `(contexte, row)`                       | `β += w_ignore` (faible)                                |
 
 Le signal `reject_challenge_appreciated` est l'élément crucial. Il décorrèle « la suggestion était pertinente comme exploration » de « je l'ai insérée ». Sans ce signal, le système collapse vers le mode confort en quelques semaines.
 
@@ -95,7 +95,7 @@ Trois familles :
 - **Suggestion d'exploration** — « Tu n'as jamais utilisé le champ lexical *organique* dans tes scènes cyberpunk. Tester ? »
 - **Anti-pattern détecté** — « Tes descriptions de combat font en moyenne 40 mots quand tes autres descriptions en font 120. Volontaire ? »
 
-Déclenchement : calcul périodique (batch nocturne) sur le profil de style. **Pas d'interruption dans le flux d'écriture.** Ces méta-suggestions ne consomment aucun Muses — décision à acter dans le document de tarification à venir.
+Déclenchement : calcul périodique (batch nocturne) sur le profil de style. **Pas d'interruption dans le flux d'écriture.** Les méta-suggestions ne consomment aucune unité d'usage — à acter dans le futur document de refonte tarifaire (cf. `philosophy.md` § Conventions).
 
 ## 5. Garde-fous
 

--- a/aidd_docs/memory/style-coaching.md
+++ b/aidd_docs/memory/style-coaching.md
@@ -18,7 +18,7 @@ Le profil de style est distinct du trust, sur un axe orthogonal.
 | Question répondue  | Cet auteur est-il fiable comme contributeur ?      | Cet auteur écrit dans quel style ?                             |
 | Sources            | Accept/reject **des autres** sur ses contribs      | Accept/édition **par lui** des suggestions reçues + contenu rédigé |
 | Forme              | Vecteur `(α, β)` par `(axe, valeur)`               | Histogrammes avec décroissance temporelle, à 4 niveaux         |
-| Usage downstream   | Pondère ses contribs entrantes (étage 2)           | Personnalise les sorties qu'on lui propose (étages 2/3/4)      |
+| Usage downstream   | Pondère ses contribs entrantes (étage 2)           | Personnalise les sorties qu'on lui propose (étages 1/2/3/4 en mode challenge, 2/3/4 en mode confort) |
 
 ### Quatre niveaux d'observation
 
@@ -105,7 +105,7 @@ Déclenchement : calcul périodique (batch nocturne) sur le profil de style. **P
 - **Mode forcé hors challenge** — un auteur peut désactiver définitivement le mode challenge. Le produit reste pleinement utile en mode confort pur. Le challenge est une option, pas une imposition.
 - **Visibilité du profil** — l'auteur voit son propre profil de style (au moins les méta-suggestions). C'est l'objet du coaching : sans visibilité, pas de prise de conscience.
 
-Note : la visibilité du **profil de style** par l'auteur diffère de la visibilité du **trust** (admin-only — cf. `learning-and-trust.md` à venir). Le profil parle d'écriture, pas de fiabilité — partager le premier ne crée pas le risque de gaming associé au second.
+Note : la visibilité du **profil de style** par l'auteur diffère de la visibilité du **trust** (admin-only — cf. `learning-and-trust.md` §4). Le profil parle d'écriture, pas de fiabilité — partager le premier ne crée pas le risque de gaming associé au second.
 
 ## 6. Hors périmètre / questions ouvertes
 


### PR DESCRIPTION
Document the architectural pivot from LoRA fine-tuning to a table-sampling
algorithm with ML-assisted stages. Captures the 4-stage generation pipeline
(selector, weighter, recombiner, filter), the 4 granularity levels (atomic
entities, slot templates, narrative beats, ready-to-use fragments), the
feature-to-stages mapping, and the asymmetric projection pipeline for
analysis features. Lists open questions and items deliberately out of scope.