### PR TITLE
feat(narrate): reçu de provenance du contrat importé — Hub-B

### DIFF
--- a/muses/narrate/contract/PROVENANCE.json
+++ b/muses/narrate/contract/PROVENANCE.json
@@ -1,0 +1,13 @@
+{
+  "receipt_version": 1,
+  "description": "Reçu de provenance du contrat /narrate importé de CN (cn-core). GÉNÉRÉ — ne pas éditer à la main : régénérer via scripts/import_narrate_contract.sh. Voir contract/README.md.",
+  "artifact": "schema.json",
+  "source_repo": "unknown",
+  "source_path": "src/scripts/narrative/generated/schema.json",
+  "source_commit": "unknown",
+  "source_commit_date": "unknown",
+  "imported_at": "2026-07-06T06:21:14+00:00",
+  "schema_sha256": "b609d8e50c9f4a350ffc8c9429329a470905a048daae3dd08c490d9f622c5c44",
+  "backfill_required": true,
+  "note": "Schéma importé en PR #83 (commit Hub a8c19a8) sans reçu de provenance — dette Hub-B. Le SHA du commit CN source n'a pas été capturé à l'époque et sera renseigné au prochain import scripté (backfill_required passe à false). `imported_at` reflète le commit Hub qui a déposé le schéma, faute de mieux."
+}

--- a/muses/narrate/contract/README.md
+++ b/muses/narrate/contract/README.md
@@ -1,0 +1,59 @@
+# Contrat de couture `/narrate` (CN → Hub)
+
+Ce dossier contient le contrat **importé de CN** (cn-core), pas défini par le Hub.
+
+| Fichier           | Rôle                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `schema.json`     | Schéma JSON du corps `POST /narrate`, recopié **verbatim** depuis CN. |
+| `PROVENANCE.json` | Reçu de provenance : de quel commit CN provient `schema.json`.       |
+
+## Invariant #4 — le Hub ne hand-type jamais le schéma
+
+`schema.json` est **généré par CN** (`packet.rs` → `generated/schema.json`) et
+recopié tel quel. Toute dérive de couture se corrige **dans CN d'abord**, puis se
+répercute ici par un réimport. On ne retouche jamais `schema.json` à la main.
+
+## Reçu de provenance (Hub-B)
+
+`PROVENANCE.json` rend la synchronisation **vérifiable**. Champs :
+
+| Champ                | Sens                                                          |
+| -------------------- | ------------------------------------------------------------- |
+| `source_repo`        | Remote `origin` du checkout CN utilisé pour l'import.         |
+| `source_path`        | Chemin du schéma généré dans le dépôt CN.                     |
+| `source_commit`      | SHA du commit CN d'où provient le schéma.                     |
+| `source_commit_date` | Date de ce commit (ISO 8601).                                 |
+| `imported_at`        | Date de l'import côté Hub.                                    |
+| `schema_sha256`      | Hash du `schema.json` importé — garde-fou anti-dérive.        |
+| `backfill_required`  | `true` tant que le SHA CN n'a pas été capturé (schéma hérité).|
+
+> **État courant.** Le `schema.json` présent a été importé en PR #83 **sans**
+> reçu (c'est la dette que Hub-B corrige). `source_commit` vaut donc `unknown` et
+> `backfill_required` est `true`. Le prochain import scripté (ci-dessous)
+> renseigne le vrai SHA et bascule le flag à `false`.
+
+## Procédure d'import (scriptée)
+
+Depuis un checkout local de CN, à la racine du dépôt Hub :
+
+```bash
+scripts/import_narrate_contract.sh <chemin-checkout-CN> [chemin-source-dans-CN]
+# ex.
+scripts/import_narrate_contract.sh ../cn-core
+```
+
+Le script, en un seul mouvement :
+
+1. refuse d'importer si le fichier source est modifié/non committé côté CN
+   (sinon le reçu ne résoudrait vers aucun commit réel) ;
+2. recopie `schema.json` **verbatim** ;
+3. régénère `PROVENANCE.json` (SHA CN, date de commit, remote, hash du schéma).
+
+Schéma et reçu ne peuvent donc pas dériver. Après import, valider la couture :
+
+```bash
+pytest tests/muses/narrate/test_provenance.py tests/muses/narrate/test_contract.py
+```
+
+`test_provenance.py` échoue si `schema.json` est édité sans repasser par le
+script (le hash enregistré ne correspond plus).

--- a/muses/narrate/schema.py
+++ b/muses/narrate/schema.py
@@ -11,6 +11,7 @@ La RACINE du schéma valide le corps de `POST /narrate` (`{ packet, n }`). Le
 
 from __future__ import annotations
 
+import hashlib
 import json
 from functools import lru_cache
 from pathlib import Path
@@ -19,6 +20,8 @@ from pathlib import Path
 EXPECTED_PACKET_SCHEMA_VERSION = 1
 
 _SCHEMA_PATH = Path(__file__).parent / "contract" / "schema.json"
+# Reçu de provenance (Hub-B) : de quel commit CN provient `schema.json`.
+_PROVENANCE_PATH = Path(__file__).parent / "contract" / "PROVENANCE.json"
 _PLACEHOLDER_KEY = "x-suddenly-placeholder"
 
 # Chemin (dans l'instance) du champ de version — sert à distinguer une
@@ -54,6 +57,30 @@ def declared_schema_version() -> int | None:
     packet = load_schema().get("$defs", {}).get("ScenePacket", {})
     const = packet.get("properties", {}).get("schema_version", {}).get("const")
     return const if isinstance(const, int) else None
+
+
+@lru_cache(maxsize=1)
+def load_provenance() -> dict:
+    """Charge le reçu de provenance du contrat (Hub-B), mémoïsé.
+
+    Décrit de quel commit CN provient `schema.json`. Écrit automatiquement par
+    `scripts/import_narrate_contract.sh` — jamais à la main.
+    """
+    return json.loads(_PROVENANCE_PATH.read_text(encoding="utf-8"))
+
+
+def schema_sha256() -> str:
+    """Hash SHA-256 du `schema.json` réellement présent sur le disque."""
+    return hashlib.sha256(_SCHEMA_PATH.read_bytes()).hexdigest()
+
+
+def provenance_matches_schema() -> bool:
+    """True si le reçu décrit bien le `schema.json` courant (pas de dérive).
+
+    Garde-fou : si quelqu'un édite `schema.json` sans repasser par le script
+    d'import, le hash enregistré dans le reçu ne correspond plus — le reçu ment.
+    """
+    return load_provenance().get("schema_sha256") == schema_sha256()
 
 
 @lru_cache(maxsize=1)

--- a/scripts/import_narrate_contract.sh
+++ b/scripts/import_narrate_contract.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Hub-B — Import scripté du contrat /narrate depuis CN (cn-core), avec reçu de
+# provenance généré automatiquement.
+#
+# Invariant #4 : le Hub ne hand-type JAMAIS le schéma. Ce script recopie
+# `schema.json` VERBATIM depuis un checkout CN et écrit `PROVENANCE.json` dans le
+# même mouvement, de sorte que le reçu résout toujours vers un commit CN réel et
+# que schéma ↔ reçu ne peuvent pas dériver.
+#
+# Usage :
+#   scripts/import_narrate_contract.sh <chemin-checkout-CN> [chemin-source-dans-CN]
+#
+# Exemple :
+#   scripts/import_narrate_contract.sh ../cn-core
+#   scripts/import_narrate_contract.sh ~/src/cn-core src/scripts/narrative/generated/schema.json
+#
+set -euo pipefail
+
+CN_DIR="${1:?usage: import_narrate_contract.sh <chemin-checkout-CN> [chemin-source]}"
+SRC_REL="${2:-src/scripts/narrative/generated/schema.json}"
+
+# Racine du dépôt Hub (le dossier parent de scripts/).
+HUB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$HUB_ROOT/muses/narrate/contract/schema.json"
+RECEIPT="$HUB_ROOT/muses/narrate/contract/PROVENANCE.json"
+
+SRC_ABS="$CN_DIR/$SRC_REL"
+
+# --- Vérifications ---------------------------------------------------------
+if [ ! -d "$CN_DIR/.git" ]; then
+  echo "✗ '$CN_DIR' n'est pas un checkout git de CN." >&2
+  exit 1
+fi
+if [ ! -f "$SRC_ABS" ]; then
+  echo "✗ Source introuvable : $SRC_ABS" >&2
+  echo "  (préciser le chemin source en 2e argument si besoin)" >&2
+  exit 1
+fi
+
+# Le reçu ne vaut que si le fichier source correspond exactement au commit HEAD.
+# On refuse d'importer depuis un arbre CN sale sur le fichier de contrat.
+if ! git -C "$CN_DIR" diff --quiet -- "$SRC_REL" \
+   || ! git -C "$CN_DIR" diff --cached --quiet -- "$SRC_REL"; then
+  echo "✗ '$SRC_REL' a des modifications non committées dans le checkout CN." >&2
+  echo "  Le reçu de provenance ne pourrait pas résoudre vers un commit réel. Committer côté CN d'abord." >&2
+  exit 1
+fi
+
+SOURCE_COMMIT="$(git -C "$CN_DIR" rev-parse HEAD)"
+SOURCE_COMMIT_DATE="$(git -C "$CN_DIR" show -s --format=%cI HEAD)"
+SOURCE_REPO="$(git -C "$CN_DIR" remote get-url origin 2>/dev/null || echo 'local')"
+IMPORTED_AT="$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+
+# --- Import verbatim + reçu (atomique via python pour l'échappement JSON) ---
+cp "$SRC_ABS" "$DEST"
+
+SCHEMA_SHA256="$(python3 -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$DEST")"
+
+python3 - "$RECEIPT" <<PY
+import json, sys
+receipt = {
+    "receipt_version": 1,
+    "description": "Reçu de provenance du contrat /narrate importé de CN (cn-core). GÉNÉRÉ — ne pas éditer à la main : régénérer via scripts/import_narrate_contract.sh. Voir contract/README.md.",
+    "artifact": "schema.json",
+    "source_repo": "$SOURCE_REPO",
+    "source_path": "$SRC_REL",
+    "source_commit": "$SOURCE_COMMIT",
+    "source_commit_date": "$SOURCE_COMMIT_DATE",
+    "imported_at": "$IMPORTED_AT",
+    "schema_sha256": "$SCHEMA_SHA256",
+    "backfill_required": False,
+    "note": "Généré au moment de l'import. schema.json est bit-identique au fichier source du commit CN ci-dessus.",
+}
+with open(sys.argv[1], "w", encoding="utf-8") as fh:
+    json.dump(receipt, fh, ensure_ascii=False, indent=2)
+    fh.write("\n")
+PY
+
+echo "✓ Contrat importé depuis CN @ ${SOURCE_COMMIT:0:12} ($SOURCE_COMMIT_DATE)"
+echo "  schema.json  sha256=$SCHEMA_SHA256"
+echo "  reçu         $RECEIPT"
+echo
+echo "Prochaine étape : lancer les tests de couture —"
+echo "  pytest tests/muses/narrate/test_provenance.py tests/muses/narrate/test_contract.py"

--- a/tests/muses/narrate/test_provenance.py
+++ b/tests/muses/narrate/test_provenance.py
@@ -1,0 +1,70 @@
+"""Hub-B — Garde-fou du reçu de provenance du contrat `/narrate`.
+
+Le reçu (`contract/PROVENANCE.json`) rend la synchronisation CN → Hub
+vérifiable : il porte le commit CN source et le hash du schéma importé. Ces
+tests prouvent que le reçu existe, est bien formé, et ne peut pas dériver du
+`schema.json` réellement déposé.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from muses.narrate import schema as contract
+
+_REQUIRED_FIELDS = {
+    "receipt_version",
+    "artifact",
+    "source_repo",
+    "source_path",
+    "source_commit",
+    "source_commit_date",
+    "imported_at",
+    "schema_sha256",
+    "backfill_required",
+}
+
+_SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def test_receipt_parses() -> None:
+    assert isinstance(contract.load_provenance(), dict)
+
+
+def test_required_fields_present() -> None:
+    missing = _REQUIRED_FIELDS - set(contract.load_provenance())
+    assert not missing, f"champs manquants dans le reçu : {missing}"
+
+
+def test_recorded_hash_matches_schema() -> None:
+    # LE test central : le reçu décrit bien le schema.json présent sur le disque.
+    # Toute édition manuelle de schema.json hors du script d'import casse ici.
+    receipt = contract.load_provenance()
+    assert _SHA256_RE.match(receipt["schema_sha256"]), "schema_sha256 mal formé"
+    assert contract.provenance_matches_schema(), (
+        "PROVENANCE.json ne correspond plus à schema.json — réimporter via "
+        "scripts/import_narrate_contract.sh"
+    )
+
+
+def test_backfill_flag_is_bool() -> None:
+    assert isinstance(contract.load_provenance()["backfill_required"], bool)
+
+
+def test_source_commit_is_real_sha_once_backfilled() -> None:
+    """Une fois l'import scripté passé, `source_commit` DOIT être un SHA git réel.
+
+    Tant que `backfill_required` est vrai (schéma hérité de PR #83), le SHA CN
+    n'est pas encore connu — on tolère `unknown`. Dès qu'il passe à faux, le reçu
+    doit résoudre vers un commit réel (Done #1 de Hub-B).
+    """
+    receipt = contract.load_provenance()
+    if receipt["backfill_required"]:
+        pytest.skip("schéma hérité (PR #83) : SHA CN à backfiller au prochain import")
+    assert _SHA1_RE.match(receipt["source_commit"]), (
+        f"source_commit doit être un SHA git 40-hex, pas {receipt['source_commit']!r}"
+    )
+    assert receipt["source_commit_date"] != "unknown"


### PR DESCRIPTION
Le dossier contract/ ne portait que schema.json, sans trace du commit CN
source : la synchro CN → Hub était non vérifiable. Ajout d'un reçu de
provenance et de son outillage, dans le respect de l'invariant #4 (le Hub
ne hand-type jamais le schéma).

- contract/PROVENANCE.json : reçu machine (source_commit, date, hash sha256).
  État hérité de #83 marqué backfill_required=true, source_commit=unknown —
  aucun SHA inventé, il sera renseigné au prochain import scripté.
- scripts/import_narrate_contract.sh : import verbatim depuis un checkout CN +
  génération automatique du reçu, en un seul mouvement (schéma ↔ reçu ne
  peuvent pas dériver ; refuse un arbre CN sale sur le fichier source).
- schema.py : load_provenance(), schema_sha256(), provenance_matches_schema().
- tests/test_provenance.py : garde-fou anti-dérive (le hash du reçu doit
  correspondre à schema.json) + exigence d'un SHA réel une fois backfillé.
- contract/README.md : procédure d'import documentée.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CgYTbbXtBNJUT7ZycYtxN4